### PR TITLE
Text Style

### DIFF
--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -158,9 +158,6 @@ class Field extends Part {
     }
 
     setSelection(senders, propertyName, propertyValue){
-        console.log(this.id);
-        console.log(propertyName);
-        console.log(propertyValue);
         // for now just allow properties of type "text-*" to be set
         if(propertyName.startsWith("text-")){
             window.System.findViewsById(this.id).forEach((view) => {

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -75,11 +75,14 @@ class Field extends Part {
             'editable',
             true
         );
+
+
         // A number of the props deal with direct text editing,
         // and so they are like commands. Examples include "undo"
         // "redo" "clear" etc. Here we use dynami props which the
         // view can respond to accordingly, but having these props have
         // no actual 'state'
+        /** TODO: these should be private commands
         this.partProperties.newDynamicProp(
             "undo",
             () => {}, // all we is a notification
@@ -95,6 +98,7 @@ class Field extends Part {
             () => {}, // all we is a notification
             () => {} // no getter
         );
+        **/
 
         // Styling
         // setting width and height to null
@@ -142,13 +146,27 @@ class Field extends Part {
         // Private command handlers
 
         this.insertRange = this.insertRange.bind(this);
+        this.setSelection = this.setSelection.bind(this);
         this.setPrivateCommandHandler("insertRange", this.insertRange);
+        this.setPrivateCommandHandler("setSelection", this.setSelection);
     }
 
     insertRange(senders, rangeId, html, css){
         window.System.findViewsById(this.id).forEach((view) => {
             view.insertRange(rangeId, html, css);
         });
+    }
+
+    setSelection(senders, propertyName, propertyValue){
+        console.log(this.id);
+        console.log(propertyName);
+        console.log(propertyValue);
+        // for now just allow properties of type "text-*" to be set
+        if(propertyName.startsWith("text-")){
+            window.System.findViewsById(this.id).forEach((view) => {
+                view.setSelection(propertyName, propertyValue);
+            });
+        }
     }
 
     get type(){

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -248,7 +248,7 @@ class FieldView extends PartView {
             // being created to wrap the contents, such as when styling is continually
             // applied ot the same selection
             let span;
-            if(docFragment.childNodes.length == 1 && docFragment.childNodes[0].nodeName == "TEXT"){
+            if(docFragment.childNodes.length == 1 && docFragment.childNodes[0].nodeName == "SPAN"){
                 span = docFragment.childNodes[0];
                 // Note the use of Obejct.values here for the DOM style attribute object
                 // that's weird
@@ -257,7 +257,7 @@ class FieldView extends PartView {
                 });
             } else {
                 // we need to create a span element to wrap the contents in style
-                span = document.createElement('text');
+                span = document.createElement('span');
                 // While tempting to use range.surroundContents() avoid this
                 // since it will fail with a non-informative error if the range
                 // includes partial nodes (ex text across various nodes)
@@ -270,8 +270,17 @@ class FieldView extends PartView {
                 span.style[key] = cssObject[key];
             });
             range.insertNode(span);
-            // TODO sort this out
-            // an empty div is frequently inserted by range.inserNode
+            this.model.partProperties.setPropertyNamed(
+                this.model,
+                'innerHTML',
+                this.textarea.innerHTML,
+                false // do not notify
+            );
+            // if there is a target and range set then send the target an update message
+            let target = this.model.partProperties.getPropertyNamed(this.model, 'target');
+            if(target){
+                this.setRangeInTarget(target, this.textarea.innerHTML);
+            }
         });
     }
 

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -282,6 +282,22 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             return msg;
         },
 
+        Command_setSelection: function(setLiteral, selectionLiteral, propNameAsLiteral, toLiteral, literalOrVarName, optionalInClause){
+            let specifiedObjectId = optionalInClause.interpret()[0] || null;
+            let args = [
+                propNameAsLiteral.interpret(), // The property name
+                literalOrVarName.interpret(), // The value or a var representing the value
+                specifiedObjectId
+            ];
+
+            let msg = {
+                type: "command",
+                commandName: "setSelection",
+                args: args
+            };
+            return msg;
+        },
+
         Command_ask: function(askLiteral, question){
             return {
                 type: "command",

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -221,6 +221,7 @@ SimpleTalk {
       | "delete" ObjectSpecifier --deleteModel
       | "delete" "property" stringLiteral "from"? ObjectSpecifier? --deleteProperty
       | "set" propertyName "to" Expression InClause? --setProperty
+      | "set" "selection" propertyName "to" Expression InClause? --setSelection
       | "add" "property" stringLiteral "to"? ObjectSpecifier? --addProperty
       | "add" systemObject stringLiteral? "to" ObjectSpecifier --addModelTo
       | "add" systemObject stringLiteral? --addModel


### PR DESCRIPTION
### Main Points ###

This PR allows for selected text in the `field` part/view to be styled. The underlying grammar-semantics is [defined](https://github.com/dkrasner/Simpletalk/compare/daniel-text-style?expand=1#diff-f189d2a29e6e2a0f4a8cd3a2f8c72779e92347a335215074c196e9bec06c5a80R224) by the `set selection [name] to [value]` which intends to mimic the set property syntax. I tried out various options (just private command/handlers, another syntax, and this seemed like the most natural). There is no current GUI/menu for this (see below). At the moment you can only set `text-*` [properties](https://github.com/dkrasner/Simpletalk/compare/daniel-text-style?expand=1#diff-fe8cb805e886cf0ee48add085fb727a743dce8f1eeab7e8559322f746c39da2aR165) on field selections, and only fields have a handler for these commands. In the future, we can think of selections for other parts. 

The underlying mechanism uses DOM ranges and document fragments. However the way that cross-element selections (ie those which don't strictly respect the DOM element tree) are reconciled you end up with an extra div before each insert point, which causes a visual line break in the text. For this I [changed](https://github.com/dkrasner/Simpletalk/compare/daniel-text-style?expand=1#diff-48ed5cd662d43c127d7e1ce0f6f561e5d6a805cb07e182d40b4f3ddea2dbb1acR164) the default paragraph selector to </br> which might or might not cause issues in other browsers. 

If multiple styling is added to the same selection, then the outer (styled) span element is re-used, i.e. I don't keep wrapping in more and more spans. 

#### trying it out #####
Type some text, select it and then send a message like `set selection "text-color" to "red"`. Or adding a few buttons which do so.


#### known issues ####
If you continue to type within or at the end of a selection, you end up inheriting the style. This is simply b/c the DOM adds children to the current parent element which is the (styled) span wrapping the selection. Going to the end of the selection and typing return/new line breaks out of the span, adding a child to their common parent. This is reasonably intuitive... but can cause confusion. 

Some properties will no longer be reflected "globally" in the field. For example, if you set a selection text-color to red and try to change the text-color or text-transparency property it will have no effect on the selection. This is simply DOM and style inheritance works. We could cycle through and update said style from all span children of the textarea, but I didn't do that just yet for the simple reason that it would not be a simple set new value (you would need to deal with rgba values for colors etc). 

I had initially planned on making a separate menu GUI in ST that could be opened with a prop change or command, and allow for selection styling and the like. But then it wasn't clear what I wanted there and how we would use it. For the moment we have a way to style selected text, if programmatically and so lets see where it takes us and what is needed.

My take is that we need to rewrite field view completely and rethink about how we deal with text, selections, styles and the like. 

#### Tests ####
JS DOM and ranges/document fragments are a real pain to work with. You essentially need to mock up your own and then you are not really testing what happens in the DOM itself (visually) which is what is important here. The grammar + interpreter changes are pretty trivial. So no tests here, but can be added if you think otherwise. 

