### PR TITLE
Dynamic pinning props with better setters

### DIFF
--- a/js/objects/utils/styleProperties.js
+++ b/js/objects/utils/styleProperties.js
@@ -183,21 +183,43 @@ const addPositioningStyleProps = (target) => {
     // particular side of its owner Part.
     // Pinning properties only have effect
     // inside of Parts with a strict layout
-    target.partProperties.newBasicProp(
+    target.partProperties.newDynamicProp(
         'pinning-top',
-        false
+        pinningSetter,
+        function(propOwner, propObject){
+            return propObject._value;
+        },
+        false, // not read only
+        false // default value
+
     );
-    target.partProperties.newBasicProp(
+    target.partProperties.newDynamicProp(
         'pinning-left',
-        false
+        pinningSetter,
+        function(propOwner, propObject){
+            return propObject._value;
+        },
+        false, // not read only
+        false // default value
+
     );
-    target.partProperties.newBasicProp(
+    target.partProperties.newDynamicProp(
         'pinning-bottom',
-        false
+        pinningSetter,
+        function(propOwner, propObject){
+            return propObject._value;
+        },
+        false, // not read only
+        false // default value
     );
-    target.partProperties.newBasicProp(
+    target.partProperties.newDynamicProp(
         'pinning-right',
-        false
+        pinningSetter,
+        function(propOwner, propObject){
+            return propObject._value;
+        },
+        false, // not read only
+        false // default value
     );
     target.partProperties.newDynamicProp(
         // Possible values for the compound
@@ -383,6 +405,58 @@ const addLayoutStyleProps = (target) => {
     );
 };
 
+/**
+  * HELPERS
+ **/
+
+const pinningSetter = (propOwner, propObject, value) => {
+    let side = propObject.name.split("-")[1];
+    let topLeft;
+    switch (side){
+    case "right":
+        topLeft = "left";
+        break;
+    case "bottom":
+        topLeft = "top";
+        break;
+    default:
+        topLeft = side;
+    }
+    // we'll need to fix and un-fix the corresponding top or left property depending
+    // on whether value is true of false, respectively
+    let prop = propOwner.partProperties.findPropertyNamed(
+        topLeft 
+    );
+    let oppositeSide;
+    switch (side){
+    case "left":
+        oppositeSide = "right";
+        break;
+    case "right":
+        oppositeSide = "left";
+        break;
+    case "top":
+        oppositeSide = "bottom";
+        break;
+    case "bottom":
+        oppositeSide = "top";
+        break;
+    }
+    if(value){
+        // first make sure that pinning-bottom is false
+        propOwner.partProperties.setPropertyNamed(
+            propOwner,
+            `pinning-${oppositeSide}`,
+            false
+        );
+        prop.readOnly = true;
+    } else {
+        // reset the value back to trigger a notification
+        prop.setValue(propOwner, prop._value);
+        prop.readOnly = false;
+    }
+    propObject._value = value;
+};
 
 const pinningAdjust = (owner, value) => {
     let sides = ['top', 'left', 'right', 'bottom'];


### PR DESCRIPTION
### Main Points ###
The main meat of this PR is in the [pinning setter](https://github.com/dkrasner/Simpletalk/compare/daniel-pinning-and-friends?expand=1#diff-3e92492eace39be8aa0e7bca71d80a35d5cda157a535b4caf89684d02ffa7a79R412)

setter makes sure that you don't pin on opposite sides,
that top/left are unchanged when a part is pinned,
and that top/left are notified when pinning is unset

This PR closes issue #5 

There are no tests here, since it's a pretty trivial change and we can test it in the UI. 