### PR TITLE
There is a property

### DIFF
--- a/js/objects/tests/test-thereisa-with-preload.js
+++ b/js/objects/tests/test-thereisa-with-preload.js
@@ -19,7 +19,7 @@ function getSemanticsFor(aPart){
     return semantics;
 }
 
-describe('"there is (not) (a|an)" command tests', () => {
+describe('"there is (not) (a|an)" conditional tests', () => {
     let semantics;
     let currentCard;
     let exampleArea;
@@ -59,6 +59,57 @@ describe('"there is (not) (a|an)" command tests', () => {
             assert.isTrue(match.succeeded());
             assert.isTrue(semantics(match).interpret());
             script = `there is a button "I exist"`;
+            match = testLanguageGrammar.match(script, 'Conditional');
+            assert.isTrue(match.succeeded());
+            assert.isTrue(semantics(match).interpret());
+        });
+    });
+});
+describe('"there is (not) a property" conditional tests', () => {
+    let semantics;
+    let currentCard;
+    describe('current card tests', () => {
+        it('Can create a semantics for current card without error', () => {
+            currentCard = System.getCurrentCardModel();
+            let initSemantics = function(){
+                semantics = getSemanticsFor(currentCard);
+            };
+            expect(initSemantics).to.not.throw();
+        });
+        it('Basic (core) property exists (without specifier)', () => {
+            let script = `there is a property "id"`;
+            let match = testLanguageGrammar.match(script, 'Conditional');
+            assert.isTrue(match.succeeded());
+            assert.isTrue(semantics(match).interpret());
+        });
+        it('Basic (core) property exists (with specifier)', () => {
+            let script = `there is a property "id" of current card`;
+            let match = testLanguageGrammar.match(script, 'Conditional');
+            assert.isTrue(match.succeeded());
+            assert.isTrue(semantics(match).interpret());
+        });
+        it('Basic (core) property doesn not exist (without specifier)', () => {
+            let script = `there is a property "new-prop"`;
+            let match = testLanguageGrammar.match(script, 'Conditional');
+            assert.isTrue(match.succeeded());
+            assert.isFalse(semantics(match).interpret());
+        });
+        it('Basic (core) property does not exist (with specifier)', () => {
+            let script = `there is a property "new-prop" of current card`;
+            let match = testLanguageGrammar.match(script, 'Conditional');
+            assert.isTrue(match.succeeded());
+            assert.isFalse(semantics(match).interpret());
+        });
+        it('Can add a property to the current card and then it will exist', () => {
+            let addScript = `add property "new-prop" to current card`;
+            let addMatch = testLanguageGrammar.match(addScript, 'Command');
+            let msg = semantics(addMatch).interpret();
+            currentCard.sendMessage(msg, currentCard);
+            let script = `there is a property "new-prop" of current card`;
+            let match = testLanguageGrammar.match(script, 'Conditional');
+            assert.isTrue(match.succeeded());
+            assert.isTrue(semantics(match).interpret());
+            script = `there is a property "new-prop"`;
             match = testLanguageGrammar.match(script, 'Conditional');
             assert.isTrue(match.succeeded());
             assert.isTrue(semantics(match).interpret());

--- a/js/objects/tests/test-thereisa-with-preload.js
+++ b/js/objects/tests/test-thereisa-with-preload.js
@@ -93,12 +93,20 @@ describe('"there is (not) a property" conditional tests', () => {
             let match = testLanguageGrammar.match(script, 'Conditional');
             assert.isTrue(match.succeeded());
             assert.isFalse(semantics(match).interpret());
+            script = `there is not a property "new-prop"`;
+            match = testLanguageGrammar.match(script, 'Conditional');
+            assert.isTrue(match.succeeded());
+            assert.isTrue(semantics(match).interpret());
         });
         it('Basic (core) property does not exist (with specifier)', () => {
             let script = `there is a property "new-prop" of current card`;
             let match = testLanguageGrammar.match(script, 'Conditional');
             assert.isTrue(match.succeeded());
             assert.isFalse(semantics(match).interpret());
+            script = `there is not a property "new-prop" of current card`;
+            match = testLanguageGrammar.match(script, 'Conditional');
+            assert.isTrue(match.succeeded());
+            assert.isTrue(semantics(match).interpret());
         });
         it('Can add a property to the current card and then it will exist', () => {
             let addScript = `add property "new-prop" to current card`;

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -491,7 +491,7 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             return true;
         },
 
-        ThereIsNotAPropertyConditional_withoutSpecifier: function(thereLiteral, isLiteral, notLiteral, aLiteral, propLiteral, propertyName){
+        ThereIsNotAPropertyConditional_withoutSpecifier: function(thereLiteral, isLiteral, notLiteral, aLiteral, propLiteral, propName){
             let property = partContext.partProperties.findPropertyNamed(propName.interpret());
             if(property){
                 return false;

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -439,7 +439,7 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             return first <= second;
         },
 
-        ThereIsAnObjectConditional: function(thereisLiteral, aOrAnLiteral, objectSpecifier){
+        ThereIsAnObjectConditional: function(thereLiteral, isLiteral, aOrAnLiteral, objectSpecifier){
             try{
                 objectSpecifier.interpret();
                 return true;
@@ -448,13 +448,55 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             };
         },
 
-        ThereIsNotAnObjectConditional: function(thereisnotaLiteral, aOrAnLiteral, objectSpecifier){
+        ThereIsNotAnObjectConditional: function(thereLiteral, isLiteral, notLiteral, aOrAnLiteral, inClause){
             try{
                 objectSpecifier.interpret();
                 return false;
             } catch(e){
                 return true;
             };
+        },
+
+        ThereIsAPropertyConditional_withSpecifier: function(thereLiteral, isLiteral, aLiteral, propertyLiteral, propName, ofLiteral, objectSpecifier){
+            let targetId = objectSpecifier.interpret();
+            let target = systemContext.partsById[targetId];
+            if(!target){
+                throw new Error(`Could not find part with id ${targetId} (${this.sourceString})`);
+            }
+            let property = target.partProperties.findPropertyNamed(propName.interpret());
+            if(property){
+                return true;
+            }
+            return false;
+        },
+
+        ThereIsAPropertyConditional_withoutSpecifier: function(thereLiteral, isLiteral, aLiteral, propertyLiteral, propName){
+            let property = partContext.partProperties.findPropertyNamed(propName.interpret());
+            if(property){
+                return true;
+            }
+            return false;
+        },
+
+        ThereIsNotAPropertyConditional_withSpecifier: function(thereLiteral, isLiteral, notLiteral, aLiteral, propertyLiteral, propName, ofLiteral, objectSpecifier){
+            let targetId = objectSpecifier.interpret();
+            let target = systemContext.partsById[targetId];
+            if(!target){
+                throw new Error(`Could not find part with id ${targetId} (${this.sourceString})`);
+            }
+            let property = target.partProperties.findPropertyNamed(propName.interpret());
+            if(property){
+                return false;
+            }
+            return true;
+        },
+
+        ThereIsNotAPropertyConditional_withoutSpecifier: function(thereLiteral, isLiteral, notLiteral, aLiteral, propLiteral, propertyName){
+            let property = partContext.partProperties.findPropertyNamed(propName.interpret());
+            if(property){
+                return false;
+            }
+            return true;
         },
 
         IfThenInline: function(ifLiteral, conditional, thenLiteral, statement, optionalComment){

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -115,8 +115,8 @@ SimpleTalk {
       | "there" "is" "a" "property" propertyName --withoutSpecifier 
 
     ThereIsNotAPropertyConditional
-      = "there" "is" "a" "not" "property" propertyName "of" ObjectSpecifier --withSpecifier 
-      | "there" "is" "a" "not" "property" propertyName --withoutSpecifier 
+      = "there" "is" "not" "a" "property" propertyName "of" ObjectSpecifier --withSpecifier 
+      | "there" "is" "not" "a" "property" propertyName --withoutSpecifier 
 
     Conditional
       = booleanLiteral --booleanLiteral

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -227,7 +227,7 @@ SimpleTalk {
     Command (a command statement)
       = "go to" ("next" | "previous") systemObject --goToDirection
       | "go to" systemObject objectId --goToByReference
-      | "answer" Expression --answer
+      | "answer" (Conditional | Expression) --answer
       | "delete" ObjectSpecifier --deleteModel
       | "delete" "property" stringLiteral "from"? ObjectSpecifier? --deleteProperty
       | "set" propertyName "to" Expression InClause? --setProperty

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -105,15 +105,25 @@ SimpleTalk {
       | Expression "is not an" Expression
 
     ThereIsAnObjectConditional
-      = "there is " ("an" | "a") ObjectSpecifier
+      = "there" "is" ("an" | "a") ObjectSpecifier
 
     ThereIsNotAnObjectConditional
-      = "there is not" ("an" | "a") ObjectSpecifier
+      = "there" "is" "not" ("an" | "a") ObjectSpecifier
+
+    ThereIsAPropertyConditional
+      = "there" "is" "a" "property" propertyName "of" ObjectSpecifier --withSpecifier 
+      | "there" "is" "a" "property" propertyName --withoutSpecifier 
+
+    ThereIsNotAPropertyConditional
+      = "there" "is" "a" "not" "property" propertyName "of" ObjectSpecifier --withSpecifier 
+      | "there" "is" "a" "not" "property" propertyName --withoutSpecifier 
 
     Conditional
       = booleanLiteral --booleanLiteral
       | ThereIsAnObjectConditional
       | ThereIsNotAnObjectConditional
+      | ThereIsAPropertyConditional
+      | ThereIsNotAPropertyConditional
       | EqualityConditional
       | NonEqualityConditional
       | KindConditional

--- a/js/ohm/tests/test-thereisa-grammar.js
+++ b/js/ohm/tests/test-thereisa-grammar.js
@@ -126,3 +126,32 @@ describe("'there is not a' ObjectSpecifier" , () => {
         });
     });
 });
+
+describe("there is a property" , () => {
+    it ("without specifier", () => {
+        const s = `there is a property "super prop"`;
+        semanticMatchTest(s, "Conditional");
+        semanticMatchTest(s, "ThereIsAPropertyConditional");
+        semanticMatchTest(s, "ThereIsAPropertyConditional_withoutSpecifier");
+    });
+    it ("with specifier", () => {
+        const s = `there is a property "super prop" of first button of current card`;
+        semanticMatchTest(s, "Conditional");
+        semanticMatchTest(s, "ThereIsAPropertyConditional");
+        semanticMatchTest(s, "ThereIsAPropertyConditional_withSpecifier");
+    });
+});
+describe("there is a property" , () => {
+    it ("without specifier", () => {
+        const s = `there is a not property "super prop"`;
+        semanticMatchTest(s, "Conditional");
+        semanticMatchTest(s, "ThereIsNotAPropertyConditional");
+        semanticMatchTest(s, "ThereIsNotAPropertyConditional_withoutSpecifier");
+    });
+    it ("with specifier", () => {
+        const s = `there is a not property "super prop" of first button of current card`;
+        semanticMatchTest(s, "Conditional");
+        semanticMatchTest(s, "ThereIsNotAPropertyConditional");
+        semanticMatchTest(s, "ThereIsNotAPropertyConditional_withSpecifier");
+    });
+});

--- a/js/ohm/tests/test-thereisa-grammar.js
+++ b/js/ohm/tests/test-thereisa-grammar.js
@@ -141,15 +141,15 @@ describe("there is a property" , () => {
         semanticMatchTest(s, "ThereIsAPropertyConditional_withSpecifier");
     });
 });
-describe("there is a property" , () => {
+describe("there is not a property" , () => {
     it ("without specifier", () => {
-        const s = `there is a not property "super prop"`;
+        const s = `there is not a property "super prop"`;
         semanticMatchTest(s, "Conditional");
         semanticMatchTest(s, "ThereIsNotAPropertyConditional");
         semanticMatchTest(s, "ThereIsNotAPropertyConditional_withoutSpecifier");
     });
     it ("with specifier", () => {
-        const s = `there is a not property "super prop" of first button of current card`;
+        const s = `there is not a property "super prop" of first button of current card`;
         semanticMatchTest(s, "Conditional");
         semanticMatchTest(s, "ThereIsNotAPropertyConditional");
         semanticMatchTest(s, "ThereIsNotAPropertyConditional_withSpecifier");


### PR DESCRIPTION
### Main Points ###

This PR adds a `there is (not) a property` conditional. It works as expected, for example:

```
answer there is a property "top"
answer there is a property "top" of this button
answer there is not a property "top"
answer there is not a property "top" of this button
```
which all return true or false. 

I have also added `Conditional` to the `answer` command grammar, so that you can run examples like the ones above. 

#### Tests ####
Both grammar and semantics tests have been added. 

This closes issue #39 