### PR TITLE
target highlight

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -407,6 +407,10 @@ editor-subparts button.add-part-button > svg {
     outline: solid 1px var(--palette-orange);
 }
 
+.highlight {
+    background-color: green!important;
+}
+
 .targeting:after {
     content: " ";
     display: block;

--- a/css/core.css
+++ b/css/core.css
@@ -419,7 +419,6 @@ editor-subparts button.add-part-button > svg {
     position: absolute;
     top: 0;
     left: 0;
-    background-color: red;
 }
 
 body.targeting-mode,

--- a/js/objects/views/ButtonView.js
+++ b/js/objects/views/ButtonView.js
@@ -56,8 +56,6 @@ class ButtonView extends PartView {
     onClick(event){
         if(event.button == 0){
             if(event.shiftKey){
-                // prevent triggering the on click message
-                event.preventDefault();
                 this.onHaloActivationClick(event);
             } else if(!this.hasOpenHalo){
                 // Send the click command message to self

--- a/js/objects/views/CardView.js
+++ b/js/objects/views/CardView.js
@@ -29,19 +29,15 @@ class CardView extends PartView {
         this.wantsHalo = false;
 
         // Bind component methods
-        this.onClick = this.onClick.bind(this);
     }
 
     afterConnected(){
-        // Add event listeners
-        this['onclick'] = this.onClick;
     }
 
     afterDisconnected(){
-        // Remove event listeners
-        this['onclick'] = null;
     }
 
+    // override the default class method
     onClick(event){
         if(event.button == 0 && event.shiftKey){
             event.preventDefault();

--- a/js/objects/views/Halo.js
+++ b/js/objects/views/Halo.js
@@ -268,8 +268,8 @@ class Halo extends HTMLElement {
             // Target button
             this.targeter = this.shadowRoot.getElementById('halo-target');
             this.targeter.addEventListener('click', this.targetElement.onHaloTarget);
-            this.targeter.addEventListener('mouseenter', this.targetElement.onHaloTargetMouseEnter);
-            this.targeter.addEventListener('mouseleave', this.targetElement.onHaloTargetMouseLeave);
+            this.targeter.addEventListener('mouseenter', this.targetElement.onHaloTargetButtonMouseEnter);
+            this.targeter.addEventListener('mouseleave', this.targetElement.onHaloTargetButtonMouseLeave);
         }
     }
 

--- a/js/objects/views/Halo.js
+++ b/js/objects/views/Halo.js
@@ -268,6 +268,8 @@ class Halo extends HTMLElement {
             // Target button
             this.targeter = this.shadowRoot.getElementById('halo-target');
             this.targeter.addEventListener('click', this.targetElement.onHaloTarget);
+            this.targeter.addEventListener('mouseenter', this.targetElement.onHaloTargetMouseEnter);
+            this.targeter.addEventListener('mouseleave', this.targetElement.onHaloTargetMouseLeave);
         }
     }
 

--- a/js/objects/views/ImageView.js
+++ b/js/objects/views/ImageView.js
@@ -85,16 +85,13 @@ class ImageView extends PartView {
     }
 
     afterConnected(){
-        this['onclick'] = this.onClick;
-
         if(!this.haloButton){
             this.initCustomHaloButton();
         }
     }
 
     afterDisconnected(){
-        this['onclick'] = null;
-    }
+ }
 
     updateImageData(imageData){
         if(this.model.isSvg){
@@ -203,28 +200,6 @@ class ImageView extends PartView {
         }
     }
 
-    onClick(event){
-        if(event.button == 0){
-            if(event.shiftKey){
-                // prevent triggering the on click message
-                event.preventDefault();
-                if(this.hasOpenHalo){
-                    this.closeHalo();
-                } else {
-                    this.openHalo();
-                }
-            } else if(!this.hasOpenHalo){
-                // Send the click command message to self
-                this.model.sendMessage({
-                    type: 'command',
-                    commandName: 'click',
-                    args: [],
-                    shouldIgnore: true // Should ignore if System DNU
-                }, this.model);
-            }
-        }
-    }
-
     openHalo(){
         // Override default. Here we add a custom button
         // when showing.
@@ -292,7 +267,6 @@ class ImageView extends PartView {
             'Edit Image URL',
             this.updateImageLink
         );
-        
     }
 };
 

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -111,7 +111,7 @@ class PartView extends HTMLElement {
 
         // misc
         this.highlight = this.highlight.bind(this);
-        this.highlight = this.highlight.bind(this);
+        this.unhighlight = this.unhighlight.bind(this);
 
         // Bind lifecycle methods
         this.afterModelSet = this.afterModelSet.bind(this);
@@ -664,7 +664,6 @@ class PartView extends HTMLElement {
             document.addEventListener('keydown', this.handleTargetKey);
             partView.addEventListener('mouseover', this.handleTargetMouseOver);
             partView.addEventListener('mouseleave', this.handleTargetMouseLeave);
-            partView.removeEventListener('click', partView.onClick);
             partView.addEventListener('click', this.handleTargetMouseClick);
         });
         document.body.classList.add('targeting-mode');
@@ -686,11 +685,22 @@ class PartView extends HTMLElement {
     }
 
     highlight(){
-        this.classList.add('highlight');
+        if(!this.name == "StackView" && !this.name == "WorldView"){
+            this._tempBackgroundColor = this.model.partProperties.getPropertyNamed(this.model, "background-color");
+            this._tempBackgroundTransparency = this.model.partProperties.getPropertyNamed(this.model, "background-transparency");
+            this.model.partProperties.setPropertyNamed(this.model, "background-color", "green");
+            this.model.partProperties.setPropertyNamed(this.model, "background-transparency", .5);
+        }
+
     }
 
     unhighlight(){
-        this.classList.remove('highlight');
+        if(!this.name == "StackView" && !this.name == "WorldView"){
+            this.model.partProperties.setPropertyNamed(this.model, "background-color", this._tempBackgroundColor);
+            this.model.partProperties.setPropertyNamed(this.model, "background-transparency", this._tempBackgroundTransparency);
+            this._tempBackgroundColor = null;
+            this._tempBackgroundTransparency = null;
+        }
     }
 
     endHaloTarget(){
@@ -708,7 +718,6 @@ class PartView extends HTMLElement {
             partView.removeEventListener('mouseover', this.handleTargetMouseOver);
             partView.removeEventListener('mouseleave', this.handleTargetMouseLeave);
             partView.removeEventListener('click', this.handleTargetMouseClick);
-            partView.addEventListener('click', partView.onClick);
         });
         document.body.classList.remove('targeting-mode');
     }
@@ -722,14 +731,14 @@ class PartView extends HTMLElement {
     handleTargetMouseOver(event){
         if(!event.target.classList.contains('targeting')){
             event.target.classList.add('targeting');
-            event.target['onclick'] = null;
+            event.target.removeEventListener('click', event.target.onClick);
         }
     }
 
     handleTargetMouseLeave(event){
         if(event.target.classList.contains('targeting')){
             event.target.classList.remove('targeting');
-            event.target['onclick'] = event.target.onClick;
+            event.target.addEventListener('click', event.target.onClick);
         }
     }
 

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -673,7 +673,7 @@ class PartView extends HTMLElement {
     onHaloTargetMouseEnter(){
         // light up the current target
         this.getCurrentTargetViews().forEach((view) => {
-            view.highlight();
+            view.highlight("rgb(54, 172, 100)"); //green
         });
     }
 
@@ -684,18 +684,18 @@ class PartView extends HTMLElement {
         });
     }
 
-    highlight(){
-        if(!this.name == "StackView" && !this.name == "WorldView"){
+    highlight(color){
+        if(this.name != "StackView" && this.name != "WorldView"){
             this._tempBackgroundColor = this.model.partProperties.getPropertyNamed(this.model, "background-color");
+            this.model.partProperties.setPropertyNamed(this.model, "background-color", color);
             this._tempBackgroundTransparency = this.model.partProperties.getPropertyNamed(this.model, "background-transparency");
-            this.model.partProperties.setPropertyNamed(this.model, "background-color", "green");
-            this.model.partProperties.setPropertyNamed(this.model, "background-transparency", .5);
+            this.model.partProperties.setPropertyNamed(this.model, "background-transparency", 1);
         }
 
     }
 
     unhighlight(){
-        if(!this.name == "StackView" && !this.name == "WorldView"){
+        if(this.name != "StackView" && this.name != "WorldView"){
             this.model.partProperties.setPropertyNamed(this.model, "background-color", this._tempBackgroundColor);
             this.model.partProperties.setPropertyNamed(this.model, "background-transparency", this._tempBackgroundTransparency);
             this._tempBackgroundColor = null;
@@ -729,8 +729,11 @@ class PartView extends HTMLElement {
     }
 
     handleTargetMouseOver(event){
+        console.log("targeting");
+        console.log(event.target);
         if(!event.target.classList.contains('targeting')){
             event.target.classList.add('targeting');
+            event.target.highlight("rgb(234, 55, 55)");
             event.target.removeEventListener('click', event.target.onClick);
         }
     }
@@ -738,6 +741,7 @@ class PartView extends HTMLElement {
     handleTargetMouseLeave(event){
         if(event.target.classList.contains('targeting')){
             event.target.classList.remove('targeting');
+            event.target.unhighlight();
             event.target.addEventListener('click', event.target.onClick);
         }
     }
@@ -756,7 +760,8 @@ class PartView extends HTMLElement {
         );
         this.endHaloTarget();
         event.stopImmediatePropagation();
-        event.target.onclick = event.target.onClick;
+        event.target.unhighlight();
+        event.target.addEventListener('click', event.target.onClick);
     }
 
     getCurrentTargetViews(){

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -84,8 +84,8 @@ class PartView extends HTMLElement {
         this.onHaloCopy = this.onHaloCopy.bind(this);
         this.onHaloTarget = this.onHaloTarget.bind(this);
         this.endHaloTarget = this.endHaloTarget.bind(this);
-        this.onHaloTargetMouseEnter = this.onHaloTargetMouseEnter.bind(this);
-        this.onHaloTargetMouseLeave = this.onHaloTargetMouseLeave.bind(this);
+        this.onHaloTargetButtonMouseEnter = this.onHaloTargetButtonMouseEnter.bind(this);
+        this.onHaloTargetButtonMouseLeave = this.onHaloTargetButtonMouseLeave.bind(this);
         this.onHaloActivationClick = this.onHaloActivationClick.bind(this);
         this.onHaloOpenEditor = this.onHaloOpenEditor.bind(this);
         this.onAuxClick = this.onAuxClick.bind(this);
@@ -97,7 +97,7 @@ class PartView extends HTMLElement {
         this.handleTargetKey = this.handleTargetKey.bind(this);
         this.handleTargetMouseClick = this.handleTargetMouseClick.bind(this);
         this.handleTargetMouseOver = this.handleTargetMouseOver.bind(this);
-        this.handleTargetMouseLeave = this.handleTargetMouseLeave.bind(this);
+        this.handleTargetMouseOut = this.handleTargetMouseLeave.bind(this);
         this.addContextMenuItems = this.addContextMenuItems.bind(this);
         this.getCurrentTargetViews = this.getCurrentTargetViews.bind(this);
 
@@ -663,21 +663,21 @@ class PartView extends HTMLElement {
         allTargets.forEach(partView => {
             document.addEventListener('keydown', this.handleTargetKey);
             partView.addEventListener('mouseover', this.handleTargetMouseOver);
-            partView.addEventListener('mouseleave', this.handleTargetMouseLeave);
+            partView.addEventListener('mouseout', this.handleTargetMouseOut);
             partView.addEventListener('click', this.handleTargetMouseClick);
         });
         document.body.classList.add('targeting-mode');
         event.stopPropagation();
     }
 
-    onHaloTargetMouseEnter(){
+    onHaloTargetButtonMouseEnter(){
         // light up the current target
         this.getCurrentTargetViews().forEach((view) => {
             view.highlight("rgb(54, 172, 100)"); //green
         });
     }
 
-    onHaloTargetMouseLeave(){
+    onHaloTargetButtonMouseLeave(){
         // light up the current target
         this.getCurrentTargetViews().forEach((view) => {
             view.unhighlight();
@@ -698,8 +698,6 @@ class PartView extends HTMLElement {
         if(this.name != "StackView" && this.name != "WorldView"){
             this.model.partProperties.setPropertyNamed(this.model, "background-color", this._tempBackgroundColor);
             this.model.partProperties.setPropertyNamed(this.model, "background-transparency", this._tempBackgroundTransparency);
-            this._tempBackgroundColor = null;
-            this._tempBackgroundTransparency = null;
         }
     }
 
@@ -716,7 +714,7 @@ class PartView extends HTMLElement {
             document.removeEventListener('keydown', this.handleTargetKey);
             partView.removeEventListener('keydown', this.handleTargetKey);
             partView.removeEventListener('mouseover', this.handleTargetMouseOver);
-            partView.removeEventListener('mouseleave', this.handleTargetMouseLeave);
+            partView.removeEventListener('mouseout', this.handleTargetMouseOut);
             partView.removeEventListener('click', this.handleTargetMouseClick);
         });
         document.body.classList.remove('targeting-mode');
@@ -729,8 +727,6 @@ class PartView extends HTMLElement {
     }
 
     handleTargetMouseOver(event){
-        console.log("targeting");
-        console.log(event.target);
         if(!event.target.classList.contains('targeting')){
             event.target.classList.add('targeting');
             event.target.highlight("rgb(234, 55, 55)");

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -664,6 +664,7 @@ class PartView extends HTMLElement {
             document.addEventListener('keydown', this.handleTargetKey);
             partView.addEventListener('mouseover', this.handleTargetMouseOver);
             partView.addEventListener('mouseleave', this.handleTargetMouseLeave);
+            partView.removeEventListener('click', partView.onClick);
             partView.addEventListener('click', this.handleTargetMouseClick);
         });
         document.body.classList.add('targeting-mode');
@@ -707,6 +708,7 @@ class PartView extends HTMLElement {
             partView.removeEventListener('mouseover', this.handleTargetMouseOver);
             partView.removeEventListener('mouseleave', this.handleTargetMouseLeave);
             partView.removeEventListener('click', this.handleTargetMouseClick);
+            partView.addEventListener('click', partView.onClick);
         });
         document.body.classList.remove('targeting-mode');
     }
@@ -732,8 +734,12 @@ class PartView extends HTMLElement {
     }
 
     handleTargetMouseClick(event){
-        event.target.classList.remove('targeting');
         event.preventDefault();
+        if(event.button == 0 && event.shiftKey){
+            this.onHaloActivationClick(event);
+            return;
+        }
+        event.target.classList.remove('targeting');
         this.model.partProperties.setPropertyNamed(
             this.model,
             'target',

--- a/js/objects/views/editors/EditorLocationInfo.js
+++ b/js/objects/views/editors/EditorLocationInfo.js
@@ -1,4 +1,5 @@
 import interpreterSemantics from '../../../ohm/interpreter-semantics.js';
+import {onLocationLinkClick, getLocationStringFor} from './utils/subparts.js';
 
 // PREAMBLE
 const arrowLeftIcon = `
@@ -63,7 +64,7 @@ const templateString = `
 class EditorLocationInfo extends HTMLElement {
     constructor(){
         super();
-        
+
         // Setup template and shadow root
         const template = document.createElement('template');
         template.innerHTML = templateString;
@@ -75,15 +76,17 @@ class EditorLocationInfo extends HTMLElement {
         // Accepted values for the kind attribute
         this.allowedKinds = ['stack', 'card', 'owner'];
 
+        // define and bind methods
+        this.getLocationStringFor = getLocationStringFor.bind(this);
+        this.onLocationLinkClick = onLocationLinkClick.bind(this);
+
         // Bound methods
         this.handleStackKind = this.handleStackKind.bind(this);
         this.handleCardKind = this.handleCardKind.bind(this);
         this.updateInfo = this.updateInfo.bind(this);
-        this.getLocationStringFor = this.getLocationStringFor.bind(this);
         this.getAncestorOfTypeFor = this.getAncestorOfTypeFor.bind(this);
         this.getLocationViews = this.getLocationViews.bind(this);
         this.onLinkClick = this.onLinkClick.bind(this);
-        this.onLocationClick = this.onLocationClick.bind(this);
         this.onMouseEnter = this.onMouseEnter.bind(this);
         this.onMouseLeave = this.onMouseLeave.bind(this);
     }
@@ -96,10 +99,8 @@ class EditorLocationInfo extends HTMLElement {
         ownerLinkButton.addEventListener('click', this.onLinkClick);
         locationLinkButton.addEventListener('click', this.onLocationClick);
         idLinkButton.addEventListener('click', this.onLocationClick);
-        ownerLinkButton.addEventListener('mouseenter', this.onMouseEnter);
         locationLinkButton.addEventListener('mouseenter', this.onMouseEnter);
         idLinkButton.addEventListener('mouseenter', this.onMouseEnter);
-        ownerLinkButton.addEventListener('mouseleave', this.onMouseLeave);
         locationLinkButton.addEventListener('mouseleave', this.onMouseLeave);
         idLinkButton.addEventListener('mouseleave', this.onMouseLeave);
     }
@@ -108,13 +109,11 @@ class EditorLocationInfo extends HTMLElement {
         let ownerLinkButton = this._shadowRoot.getElementById('owner-link');
         let locationLinkButton = this._shadowRoot.getElementById('location-link');
         let idLinkButton = this._shadowRoot.getElementById('id-link');
-        ownerLinkButton.removeEventListener('click', this.onLinkClick);
         locationLinkButton.removeEventListener('click', this.onLocationClick);
         idLinkButton.removeEventListener('click', this.onLocationClick);
         ownerLinkButton.removeEventListener('mouseenter', this.onMouseEnter);
         locationLinkButton.removeEventListener('mouseenter', this.onMouseEnter);
         idLinkButton.removeEventListener('mouseenter', this.onMouseEnter);
-        ownerLinkButton.removeEventListener('mouseleave', this.onMouseLeave);
         locationLinkButton.removeEventListener('mouseleave', this.onMouseLeave);
         idLinkButton.removeEventListener('mouseleave', this.onMouseLeave);
     }
@@ -214,20 +213,6 @@ class EditorLocationInfo extends HTMLElement {
         this.updateInfo();
     }
 
-    getLocationStringFor(aPart){
-        let result = "";
-        let currentPart = aPart;
-        let currentOwner = aPart._owner;
-        while(currentOwner){
-            let indexInParent = currentOwner.subparts.indexOf(currentPart) + 1;
-            result += `${currentPart.type} ${indexInParent} of `;
-            currentPart = currentPart._owner;
-            currentOwner = currentOwner._owner;
-        }
-        result += 'this world';
-        return result;
-    }
-
     getAncestorOfTypeFor(aPart, aType){
         let result;
         let currentOwner = aPart._owner;
@@ -251,28 +236,9 @@ class EditorLocationInfo extends HTMLElement {
         }
     }
 
-    onLocationClick(event){
-        let input = document.createElement('input');
-        let span = event.currentTarget.querySelector('span');
-        input.style.position = 'absolute';
-        input.style.opacity = 0;
-        document.body.append(input);
-        let currentFocus = document.activeElement;
-        input.focus();
-        if(span.parentElement.id == 'id-link'){
-            input.value = this.getAttribute('ref-id');
-        } else {
-            input.value = span.textContent;
-        }
-        input.select();
-        document.execCommand('copy');
-        input.remove();
-        currentFocus.focus();
-    }
-
     onMouseEnter(event){
         this.getLocationViews(event).forEach((view) => {
-            view.highlight();
+            view.highlight("rgb(54, 172, 100)"); // green
         });
     }
 

--- a/js/objects/views/editors/EditorSubpartsPane.js
+++ b/js/objects/views/editors/EditorSubpartsPane.js
@@ -263,7 +263,9 @@ class EditorSubpartsPane extends HTMLElement {
         let currentPart = aPart;
         let currentOwner = aPart._owner;
         while(currentOwner){
-            let indexInParent = currentOwner.subparts.indexOf(currentPart) + 1;
+            let indexInParent = currentOwner.subparts.filter((subpart) => {
+                return subpart.type == currentPart.type;
+            }).indexOf(currentPart) + 1;
             result += `${currentPart.type} ${indexInParent} of `;
             currentPart = currentPart._owner;
             currentOwner = currentOwner._owner;

--- a/js/objects/views/editors/utils/subparts.js
+++ b/js/objects/views/editors/utils/subparts.js
@@ -1,0 +1,37 @@
+ const getLocationStringFor = (aPart) => {
+        let result = "";
+        let currentPart = aPart;
+        let currentOwner = aPart._owner;
+        while(currentOwner){
+            let indexInParent = currentOwner.subparts.filter((subpart) => {
+                return subpart.type == currentPart.type;
+            }).indexOf(currentPart) + 1;
+            result += `${currentPart.type} ${indexInParent} of `;
+            currentPart = currentPart._owner;
+            currentOwner = currentOwner._owner;
+        }
+        result += 'this world';
+        return result;
+}
+
+
+const onLocationLinkClick = (event) => {
+        let text = event.currentTarget.querySelector('span').textContent;
+        let input = document.createElement('input');
+        input.style.position = 'absolute';
+        input.style.opacity = 0;
+        document.body.append(input);
+        let currentFocus = document.activeElement;
+        input.focus();
+        input.value = text;
+        console.log(input.value);
+        input.select();
+        document.execCommand('copy');
+        input.remove();
+        currentFocus.focus();
+}
+
+export {
+    getLocationStringFor,
+    onLocationLinkClick
+};


### PR DESCRIPTION
### Main Points ###

This PR introduces a number target related UI enhancements and fixes a bunch of bugs. 

Enhancements:
when you hover over the halo target icon/button it will highlight the current target (if there is one)
when you mouseover a potential target (in targeting-mode) the target will be highlighted (this is as before but the mechanism is different, see below)
when you hover over any object specifier (either a location string, or a subpart display) in the editor the corresponding part will be highlighted. 

#### on highlighting ####
Highlighting is done via the [highlight/unhighlight methods](https://github.com/dkrasner/Simpletalk/compare/daniel-target-highlight?expand=1#diff-f8a644f39713f7d56b51b944769a8733fceb081884704c2a73b93c232b554560R687). 

There are two reason I introduced these. 

First, they use part properties which means that that the entire system, including the nav can respond to these changes. Other than simply being "the thing you expect" given ST's liveliness, it is also quite useful when looking at parts which are hidden by the editor. For example, if you add a new part it is currently placed at (0,0) and so the editor hides it but with the nav open you can hover over and see it light up. Of course, there are other ways to deal with this but I find it pretty convenient. 

Second, we can override the base class implementation and have different parts highlight the way they need. This is not = done currently but might be useful in parts like `window` or `area` which often have their entire space taken up, or covered, by other elements. Here we could highlight the borders for example etc

The one thing I do not like about this whole setup is that in order to go back to the original (pre-highlight) state we need to cache property values, like [so](https://github.com/dkrasner/Simpletalk/compare/daniel-target-highlight?expand=1#diff-f8a644f39713f7d56b51b944769a8733fceb081884704c2a73b93c232b554560R690). This is clearly bad design, but perhaps it is ok for now. (I have been thinking about a more general undo/redo for properties...). Moreover, given potential race condition between DOM events and our prop change lifecycle you can get stuck... This is one reason I use `mouseout` as opposed to `mouseleave` event here since it seems to work better. TBD

#### Bugs ####
If you target selected a button then the click event would fire. The easiest way to see this is to target select any button in the toolbox and see it still run the `on click` handler. We had `event.preventDeault()`'s and related in the right places but this was not working simply b/c we had multiple handlers on many parts. In short, there were two issues: we never committed to the `eventListener()` API, and still had `onclick` properties floating around, and there was some sloppiness about how events were added and removed (in the complex event lifecycles we introduced with halos, targeting etc). I have gone through and removed **all** references to js object event properties (at least all I could find). This is also the reason I was noticing multiple events being fired for clicks in the past, and debugging is much easier now as a result. 

In addition, this was causing discrepancies in how the halo was activated (shift-left button or auxiliary) and sometimes failing to fire at all with shift-left. These should now be resolved.  

(Note: we use `.onClick` in our elements, which is very close to the `.onclick` DOM element event property. We should either change these to something like `.st-onClick` or just be very careful) 

The editor had a location string bug which I fixed [here](https://github.com/dkrasner/Simpletalk/compare/daniel-target-highlight?expand=1#diff-939249c16e4239cb60872cb8120643ddc43074d441646700e23465f997ff24c5R1). In addition, I made a editor utils folder since I didn't want to fix this location string generator in 2 different places and I think in general the editor can be cleaned up/simplified. 

closes #4 


