### PR TITLE
Nav Bug Fixes 2

### DIFF
--- a/js/objects/utils/clipboard.js
+++ b/js/objects/utils/clipboard.js
@@ -16,6 +16,7 @@ class STClipboard {
         // Bound methods
         this.copyPart = this.copyPart.bind(this);
         this.pasteContentsInto = this.pasteContentsInto.bind(this);
+        this._createLensedChildren = this._createLensedChildren.bind(this);
     }
 
     copyPart(aPart){
@@ -82,6 +83,7 @@ class STClipboard {
                         newLensView.setAttribute('lens-part-id', newPart.id);
                         newLensView.setAttribute('role', 'lens');
                         lensView.appendChild(newLensView);
+                        this._createLensedChildren(newLensView, newPart.subparts);
                     });
                     
                     return;
@@ -91,6 +93,20 @@ class STClipboard {
                 });
         });
         return Promise.all(promises);
+    }
+
+    _createLensedChildren(aLensView, subparts){
+        subparts.forEach(subpart => {
+            let newLensView = document.createElement(
+                this.system.tagNameForViewNamed(subpart.type)
+            );
+            newLensView.setModel(subpart);
+            newLensView.removeAttribute('part-id');
+            newLensView.setAttribute('lens-part-id', subpart.id);
+            newLensView.setAttribute('role', 'lens');
+            aLensView.appendChild(newLensView);
+            this._createLensedChildren(newLensView, subpart.subparts);
+        });
     }
     
     get isEmpty(){

--- a/js/objects/views/StackView.js
+++ b/js/objects/views/StackView.js
@@ -56,7 +56,13 @@ class StackView extends PartView {
             this.model,
             'current'
         );
-        let nextCurrentCard = this.querySelector(`:scope > st-card[part-id="${nextCurrentId}"]`);
+        let shouldNotify = false;
+        let selector = `:scope > st-card[part-id="${nextCurrentId}"]`;
+        if(this.isLensed){
+            selector = `:scope > st-card[lens-part-id="${nextCurrentId}"]`;
+            shouldNotify = true;
+        }
+        let nextCurrentCard = this.querySelector(selector);
         // if there is no currentCard and no next currentCard we set it to be the first
         // card child (this can happen when new ids are created on deserialization and so
         // the current property stored id is no longer relevant)
@@ -70,7 +76,7 @@ class StackView extends PartView {
                 this.model,
                 "current",
                 nextCurrentCard.id,
-                false // do not notify
+                shouldNotify
             );
         }
         if(nextCurrentCard){


### PR DESCRIPTION
## What ##
This PR introduces fixes for two Nav-related bugs, outlined below.
  
### Bug 1: StackRow wrapped Stack views not tracking current card ###
Whenever we navigated to a new Card, either from the Nav or somewhere in the main environment, the StackRow wrapped view would not update to show the current card. Instead, it would continue to show the first card.
  
This bug appeared when we switched from the "subpart index" method of setting current-ness to the "store an explicit id" method.
  
The solution was to update `handleCurrentChange` in `PartView.js` to set its selector based on whether the current View object is lensed or not, and to also notify of the change in cases where it is.
  
### Bug 2: Pasted Parts containing subtrees not appearing in Nav ###
If we pasted a given Part that contained trees of subparts, like an area or a window, only the parent PartView (an none of its descendants) would appear lensed within the Nav wrapped views. This was due to an oversight in the clipboard's implementation of paste, which was not creating new child lensed views recursively.
  
## Closes ##
#62 