### PR TITLE
Field Fixes and Syntax Highlighting

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -958,31 +958,19 @@ System._commandHandlers['openScriptEditor'] = function(senders, targetId){
     area.partProperties.setPropertyNamed(area, "height", "fill");
 
     // script field
-    let targetScript = target.partProperties.getPropertyNamed(target, "script");
-    let newHTML = targetScript;
-    if(targetScript){
-        // Attempt to highlight syntax of the text in the script field
-        let semantics = System.grammar.createSemantics();
-        semantics.addOperation('highlightSyntax', createHighlighter());
-        let rules = ["MessageHandlerOpen", "MessageHandlerClose"];
-        let lines = targetScript.split("\n").map(lineString => {
-            for(let i = 0; i < rules.length; i++){
-                let rule = rules[i];
-                let match = System.grammar.match(lineString, rule);
-                if(match.succeeded()){
-                    return semantics(match).highlightSyntax().outerHTML;
-                }
-            }
-            return lineString;
-        });
-        newHTML = lines.join("\n");
-    }
-    
-    
-    scriptField.partProperties.setPropertyNamed(scriptField, "innerHTML", newHTML);
+    let targetScript = target.partProperties.getPropertyNamed(target, "script"); 
+    scriptField.partProperties.setPropertyNamed(scriptField, "text", targetScript);
     scriptField.partProperties.setPropertyNamed(scriptField, "horizontal-resizing", "space-fill");
     scriptField.partProperties.setPropertyNamed(scriptField, "vertical-resizing", "space-fill");
 
+    // Setup syntax highlight
+    scriptField.sendMessage({
+        type: "command",
+        commandName: "highlightSyntax",
+        args: []
+    }, scriptField);
+    
+    
     // setup up the save button properties
     saveButton.partProperties.setPropertyNamed(saveButton, "name", "Save Script");
     saveButton.partProperties.setPropertyNamed(saveButton, "text-size", 20);

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -113,7 +113,7 @@ const System = {
                 });
         } else {
             this.loadFromEmpty();
-            
+ 
             // By default, we render the World in the
             // Comprehensive Editor
             this.editor.render(this.world);

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -161,6 +161,8 @@ class Field extends Part {
         this.setSelection = this.setSelection.bind(this);
         this.setPrivateCommandHandler("insertRange", this.insertRange);
         this.setPrivateCommandHandler("setSelection", this.setSelection);
+        this.setPrivateCommandHandler("highlightSyntax", this.highlightSyntax);
+        this.setPrivateCommandHandler("unhighlightSyntax", this.unhighlightSyntax);
     }
 
     insertRange(senders, rangeId, html, css){
@@ -175,6 +177,20 @@ class Field extends Part {
             window.System.findViewsById(this.id).forEach((view) => {
                 view.setSelection(propertyName, propertyValue);
             });
+        }
+    }
+
+    highlightSyntax(){
+        let view = window.System.findViewById(this.id);
+        if(view){
+            view.highlightSyntax();
+        }
+    }
+
+    unhighlightSyntax(){
+        let view = window.System.findViewById(this.id);
+        if(view){
+            view.unhighlightSyntax();
         }
     }
 

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -44,7 +44,7 @@ class Field extends Part {
 
         this.partProperties.newBasicProp(
             'innerHTML',
-            ''
+            '<br>' 
         );
 
         this.partProperties.newBasicProp(

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -61,6 +61,11 @@ class Field extends Part {
             (owner, prop, value, notify) => {
                 prop._value = value;
                 if(notify){
+                    if(!value){
+                        value = "<br>";
+                    }
+                    // replace all newline characters with <br>
+                    value = value.replace(/\n/g, "<br>");
                     owner.partProperties.setPropertyNamed(owner, 'innerHTML', value, notify);
                 }
             },

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -44,7 +44,7 @@ class Field extends Part {
 
         this.partProperties.newBasicProp(
             'innerHTML',
-            '<br>' 
+            ''
         );
 
         this.partProperties.newBasicProp(
@@ -61,11 +61,13 @@ class Field extends Part {
             (owner, prop, value, notify) => {
                 prop._value = value;
                 if(notify){
+                    /*
                     if(!value){
                         value = "<br>";
                     }
                     // replace all newline characters with <br>
                     value = value.replace(/\n/g, "<br>");
+                    */
                     owner.partProperties.setPropertyNamed(owner, 'innerHTML', value, notify);
                 }
             },

--- a/js/objects/utils/AltSyntaxHighlighter.js
+++ b/js/objects/utils/AltSyntaxHighlighter.js
@@ -1,0 +1,69 @@
+/** Second pass at syntax highlighter semantics **/
+const syntaxSpan = (ruleName) => {
+    let span = document.createElement('span');
+    span.classList.add('st-syntax');
+    span.setAttribute('data-st-rule', ruleName);
+    return span;
+}
+
+const createHighlighter = (fieldElement) => {
+    return {
+        MessageHandlerOpen: function(literalOn, messageName, optionalParamList){
+            let span = syntaxSpan("MessageHandlerOpen");
+            let onSpan = syntaxSpan("keyword");
+            onSpan.append("on ");
+            span.append(onSpan);
+
+            // Append sub-rules
+            span.append(messageName.highlightSyntax());
+            span.append(...optionalParamList.highlightSyntax());
+
+            return span;
+        },
+
+        MessageHandlerClose(literalEnd, messageName){
+            let span = syntaxSpan("MessageHandlerClose");
+            let endSpan = syntaxSpan("keyword");
+            endSpan.append("end ");
+            span.append(endSpan);
+
+            // Add the parts
+            span.append(messageName.highlightSyntax());
+
+            return span;
+        },
+
+        ParameterList: function(paramString){
+            let outer = syntaxSpan("ParameterList");
+            let innerItems = paramString.asIteration().children.map(paramName => {
+                let span = syntaxSpan("ParameterList-item");
+                span.append(paramName.sourceString);
+                return span.outerHTML;
+            });
+            outer.innerHTML = innerItems.join(", ");
+            return outer;
+            
+        },
+
+        messageName: function(string){
+            let span = document.createElement('span');
+            span.classList.add('st-syntax');
+            span.setAttribute('data-st-rule', 'messageName');
+            span.append(string.sourceString + " ");
+            return span;
+        },
+
+        keyword: function(string){
+            let span = document.createElement('span');
+            span.classList.add('st-syntax');
+            span.setAttribute('data-st-rule', 'keyword');
+            span.append(string.sourceString);
+            return span;
+        }
+    };
+};
+
+export {
+    createHighlighter,
+    createHighlighter as default
+};

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -135,6 +135,9 @@ class FieldView extends PartView {
             this.textarea.textContent = value;
         });
         this.onPropChange('innerHTML', (value, id) => {
+            if(!value){
+                value = "<br>";
+            }
             this.textarea.innerHTML = value;
             this.model.partProperties.setPropertyNamed(
                 this.model,
@@ -288,6 +291,11 @@ class FieldView extends PartView {
     onInput(event){
         event.stopPropagation();
         event.preventDefault();
+        let innerHTML = event.target.innerHTML;
+        if(!innerHTML.endsWith("<br>")){
+            innerHTML += "<br>";
+            event.target.innerHTML = innerHTML;
+        }
 
         if(this.editorCompleter){
             // TODO sort out how this would work
@@ -318,7 +326,17 @@ class FieldView extends PartView {
         // prevent the default tab key to leave focus on the field
         if(event.key==="Tab"){
             event.preventDefault();
-            document.execCommand('insertHTML', false, '&#x9');
+            //document.execCommand('insertHTML', false, '&#x9');
+            let sel = document.getSelection();
+            let range = sel.getRangeAt(0);
+
+            let tabNodeValue = '\t';
+            let tabNode = document.createTextNode(tabNodeValue);
+
+            range.insertNode(tabNode);
+
+            range.setStartAfter(tabNode);
+            range.setEndAfter(tabNode);
         };
     }
 

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -96,6 +96,7 @@ class FieldView extends PartView {
 
         // Bind methods
         this.onInput = this.onInput.bind(this);
+        this.onBeforeInput = this.onBeforeInput.bind(this);
         this.onClick = this.onClick.bind(this);
         this.onKeydown = this.onKeydown.bind(this);
         this.onMousedown = this.onMousedown.bind(this);
@@ -151,6 +152,7 @@ class FieldView extends PartView {
         this.textarea = this._shadowRoot.querySelector('.field-textarea');
 
         this.textarea.addEventListener('input', this.onInput);
+        // this.textarea.addEventListener('beforeinput', this.onBeforeInput);
         this.textarea.addEventListener('keydown', this.onKeydown);
         this.textarea.addEventListener('mousedown', this.onMousedown);
         // No need to add a click listener as the base PartView class does that
@@ -159,11 +161,12 @@ class FieldView extends PartView {
         // the textarea), we need to have the default paragraph tag = </br>. Otherwise
         // the insert new line is of the form <div></br><div> which causes the appearance
         // of newlines when nodes are inserted into a range
-        document.execCommand("defaultParagraphSeparator", false, "br");
+        // document.execCommand("defaultParagraphSeparator", false, "br");
     }
 
     afterDisconnected(){
         this.textarea.removeEventListener('input', this.onInput);
+        // this.textarea.removeEventListener('beforeinput', this.onBeforeInput);
         this.textarea.removeEventListener('keydown', this.onKeydown);
         this.textarea.removeEventListener('mousedown', this.onMousedown);
     }
@@ -282,14 +285,31 @@ class FieldView extends PartView {
         });
     }
 
+    onBeforeInput(event){
+        if(event.inputType == "insertParagraph"){
+            //event.stopPropagation();
+            event.preventDefault();
+            let sel = document.getSelection();
+            let range = sel.getRangeAt(0);
+
+            let br = document.createElement('br');
+            let br2 = document.createElement('br');
+            range.insertNode(br);
+            range.collapse(false);
+            range.insertNode(br2);
+            range.setStartAfter(br2);
+            range.setEndAfter(br2);
+        }
+    }
+
     onInput(event){
-        event.stopPropagation();
-        event.preventDefault();
         let innerHTML = event.target.innerHTML;
+        /*
         if(!innerHTML.endsWith("<br>")){
             innerHTML += "<br>";
             event.target.innerHTML = innerHTML;
         }
+        */
 
         if(this.editorCompleter){
             // TODO sort out how this would work

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -131,13 +131,7 @@ class FieldView extends PartView {
         // setting and still allow to not loose markup.
         // 'innerHTML' is a BasicProp. See how these are set, without
         // notification in this.onInput()
-        this.onPropChange('text', (value, id) => {
-            this.textarea.textContent = value;
-        });
         this.onPropChange('innerHTML', (value, id) => {
-            if(!value){
-                value = "<br>";
-            }
             this.textarea.innerHTML = value;
             this.model.partProperties.setPropertyNamed(
                 this.model,

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -788,6 +788,8 @@ class PartView extends HTMLElement {
                     event.clientY
                 );
             }
+        } else {
+            event.stopPropagation();
         }
     }
 

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -54,7 +54,7 @@ const createInterpreterSemantics = (partContext, systemContext) => {
         Script: function(scriptParts, _){
             return scriptParts.interpret();
         },
-        MessageHandler: function(handlerOpen, optionalStatementList, handlerClose){
+        MessageHandler: function(handlerOpen, lineTerm, optionalStatementList, handlerClose){
             let {messageName, parameters} = handlerOpen.interpret();
             let handlerFunction = function(senders, ...args){
 
@@ -99,7 +99,7 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             partContext._commandHandlers[messageName] = handlerFunction;
         },
 
-        MessageHandlerOpen: function(literalOn, messageName, optionalParameterList, newLine){
+        MessageHandlerOpen: function(literalOn, messageName, optionalParameterList){
             // Because the ParameterList here is optional, if
             // it is set it will be in the form of a size 1 array.
             // This single array item will itself be an array of the

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -16,13 +16,13 @@ SimpleTalk {
     // Note: to distinguish from functions message handler parameters are not
     // parenthetical; moreover, message names are more restrictive
     MessageHandlerOpen
-      = "on" messageName ParameterList? lineTerminator
+      = "on" messageName ParameterList?
 
     MessageHandlerClose
       = "end" messageName
 
     MessageHandler
-      = MessageHandlerOpen StatementList? MessageHandlerClose
+      = MessageHandlerOpen lineTerminator StatementList? MessageHandlerClose
 
     // TODO should we insist that authered messages start with a lower case letter?
     Message


### PR DESCRIPTION
## What ##
This PR implements two things:
1. Basic syntax highlighting, which occurs only when you send a field the `highlightSyntax` command;
2. Fixes to contenteditable inputs that were screwing up line spacing and carriage returns, especially across browsers