### PR TITLE
Editor input 

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -969,10 +969,11 @@ System._commandHandlers['openScriptEditor'] = function(senders, targetId){
         commandName: "highlightSyntax",
         args: []
     }, scriptField);
-    
-    
+
+
     // setup up the save button properties
     saveButton.partProperties.setPropertyNamed(saveButton, "name", "Save Script");
+    saveButton.partProperties.setPropertyNamed(saveButton, "width", "fill");
     saveButton.partProperties.setPropertyNamed(saveButton, "text-size", 20);
     saveButton.partProperties.setPropertyNamed(saveButton, "target", `part id ${target.id}`);
 

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -960,8 +960,8 @@ System._commandHandlers['openScriptEditor'] = function(senders, targetId){
     // script field
     let targetScript = target.partProperties.getPropertyNamed(target, "script"); 
     scriptField.partProperties.setPropertyNamed(scriptField, "text", targetScript);
-    scriptField.partProperties.setPropertyNamed(scriptField, "horizontal-resizing", "space-fill");
-    scriptField.partProperties.setPropertyNamed(scriptField, "vertical-resizing", "space-fill");
+    scriptField.partProperties.setPropertyNamed(scriptField, "height", "fill");
+    scriptField.partProperties.setPropertyNamed(scriptField, "width", "fill");
 
     // Setup syntax highlight
     scriptField.sendMessage({

--- a/js/objects/views/editors/EditorPropItem.js
+++ b/js/objects/views/editors/EditorPropItem.js
@@ -230,7 +230,15 @@ class EditorPropItem extends HTMLElement {
 
     onAcceptClick(event){
         let value = this.inputElement.value;
-        if(this.inputElement.type == 'number' || this.inputElement.type == 'range'){
+        if(this.inputElement.type == 'number'){
+            value = parseFloat(value);
+            if(isNaN(value)){
+                // if we can't parse the value just let it go through
+                // as it might be a prop style keyword such as "fill"
+                // TODO: we might want to limit this to a set of prop keywords
+                value = this.inputElement.value;
+            }
+        } else if(this.inputElement.type == 'range'){
             value = parseFloat(value);
         } else if(this.inputElement.type == 'checkbox'){
             value = this.inputElement.checked;


### PR DESCRIPTION
The editor input was not accepting keywords such as "fill" which is a valid style prop value (example "width"). This is a small fix here that will probably need to be revisited later. 

Also the fixing styling in script editor save button has been messed up since the last 2 PR's:
![image](https://user-images.githubusercontent.com/1154326/124929520-de5a1700-e000-11eb-9b3b-6106fd22c6f5.png)
