### PR TITLE
Submenus in ContextMenu

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -455,6 +455,11 @@ body.targeting-mode [part-id] {
     color: white;
 }
 
+.context-menu-item:hover > st-context-menu {
+    background-color: white;
+    color: black;
+}
+
 .context-menu-spacer {
     display: block;
     height: 1px;

--- a/js/objects/views/contextmenu/ContextMenu.js
+++ b/js/objects/views/contextmenu/ContextMenu.js
@@ -114,6 +114,7 @@ class ContextMenu extends HTMLElement {
             submenu.classList.add('context-submenu', 'submenu-hidden');
             submenu.setAttribute('slot', 'submenu');
             itemEl.append(submenu);
+            itemEl.showCaret();
         }
         this.append(itemEl);
     }

--- a/js/objects/views/contextmenu/ContextMenuItem.js
+++ b/js/objects/views/contextmenu/ContextMenuItem.js
@@ -1,0 +1,44 @@
+const templateString = `
+<style>
+    :host {
+        display: flex;
+        position: relative;
+    }
+    .submenu-area {
+        display: none;
+        position: absolute;
+        left: 100%;
+        top: 0px;
+    }
+
+    :host(:hover) .submenu-area {
+        display: flex;
+    }
+</style>
+<div class="label-area">
+    <span class="label"><slot></slot></span>
+    <div class="caret hidden"></div>
+</div>
+<div class="submenu-area">
+    <slot name="submenu"></slot>
+</div>
+`;
+
+class ContextMenuItem extends HTMLElement {
+    constructor(){
+        super();
+
+        // Setup shadow dom and template
+        this.template = document.createElement('template');
+        this.template.innerHTML = templateString;
+        this._shadowRoot = this.attachShadow({mode: 'open'});
+        this._shadowRoot.append(
+            this.template.content.cloneNode(true)
+        );
+    }
+};
+
+export {
+    ContextMenuItem,
+    ContextMenuItem as default
+};

--- a/js/objects/views/contextmenu/ContextMenuItem.js
+++ b/js/objects/views/contextmenu/ContextMenuItem.js
@@ -14,10 +14,24 @@ const templateString = `
     :host(:hover) .submenu-area {
         display: flex;
     }
+
+    .label-area {
+        display: flex;
+        align-items: center;
+    }
+
+    .caret.hidden {
+        display: none;
+    }
+    .caret {
+        display: block;
+        margin-left: auto;
+        font-size: 1.1em;
+    }
 </style>
 <div class="label-area">
     <span class="label"><slot></slot></span>
-    <div class="caret hidden"></div>
+    <div class="caret hidden">→</div>
 </div>
 <div class="submenu-area">
     <slot name="submenu"></slot>
@@ -35,6 +49,15 @@ class ContextMenuItem extends HTMLElement {
         this._shadowRoot.append(
             this.template.content.cloneNode(true)
         );
+
+        // Bound methods
+        this.showCaret = this.showCaret.bind(this);
+    }
+
+    showCaret(){
+        let caretEl = this._shadowRoot.querySelector('.caret');
+        caretEl.classList.remove('hidden');
+        
     }
 };
 


### PR DESCRIPTION
## What ##
This PR adds the capability to add submenus to any ContextMenu item.
  
## Important Changes ##
In order to facilitate this capability, we've added a new component called ContextMenuItem (element: `st-context-menu-item`) and have updated the `addMenuItem()` method of the context menu to generate these elements.
  
For now, I've added a single submenu item to most Parts: the ability to add new Parts to the model in context. For Parts that don't accept any subparts (like a button), the menu item does not appear at all in the context menu. Otherwise, the item has a caret and will reveal the submenu when hovered over. This submenu will display all Part names that the current context accepts as subparts. Clicking on one of them will add that part to the model that is in context.
  
This is a quicker way to add new parts to some other part.
  
For an example of how to add a submenu, see the ["add part" implementation here](https://github.com/dkrasner/Simpletalk/blob/eric-additional-contextmenu/js/objects/views/contextmenu/ContextMenu.js#L243).