### PR TITLE
fixing multiple grammar fields opening on grammar error

### DIFF
--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -63,8 +63,14 @@ const errorHandler = {
             }
             scriptEditor.model.partProperties.setPropertyNamed(scriptEditor.model, "text", text);
         }
-        // open the grammar
-        this._openGrammar(aMessage.partId, ruleName);
+        // open the grammar if there is not one open already
+        let currentCard = window.System.getCurrentCardModel();
+        let grammar = currentCard.subparts.filter((part) => {
+            return (part.type == "field") && (part.partProperties.getPropertyNamed(part, "name") == "SimpleTalk");
+        });
+        if(grammar.length == 0){
+            this._openGrammar(aMessage.partId, ruleName);
+        }
     },
 
     handleMessageNotUnderstood(aMessage){


### PR DESCRIPTION
Due to the nav implementation change subscription model (for stack row and card row lens elements) we were getting 3 Simpletalk grammar fields opening for each error. This was a bit annoying. 