### PR TITLE
Halo rotate (and resize bug)

### DIFF
--- a/js/objects/views/Halo.js
+++ b/js/objects/views/Halo.js
@@ -66,6 +66,13 @@ const settingsIcon = `
 </svg>
 `;
 
+const rotateIcon = `
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-rotate-clockwise" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <path d="M4.05 11a8 8 0 1 1 .5 4m-.5 5v-5h5"></path>
+</svg>
+`;
+
 const templateString = `
 <style>
  :host {
@@ -167,6 +174,12 @@ const templateString = `
     <div id="halo-resize" class="halo-button" title="Resize this part">
         ${growIcon}
     </div>
+    <div id="halo-script-edit" class="halo-button" title="Edit this part's script">
+        ${editIcon}
+    </div>
+    <div id="halo-edit" class="halo-button" title="Edit this part">
+        ${settingsIcon}
+    </div>
     <slot name="bottom-row"></slot>
 </div>
 
@@ -184,11 +197,8 @@ const templateString = `
 </div>
 
 <div id="halo-right-column" class="halo-column">
-    <div id="halo-script-edit" class="halo-button" title="Edit this part's script">
-        ${editIcon}
-    </div>
-    <div id="halo-edit" class="halo-button" title="Edit this part">
-        ${settingsIcon}
+    <div id="halo-rotate" class="halo-button" title="Rotate this part">
+        ${rotateIcon}
     </div>
     <slot name="right-column"></slot>
 </div>
@@ -217,6 +227,9 @@ class Halo extends HTMLElement {
         this.onResizeMouseDown = this.onResizeMouseDown.bind(this);
         this.onResizeMouseUp = this.onResizeMouseUp.bind(this);
         this.onResizeMouseMove = this.onResizeMouseMove.bind(this);
+        this.onRotateMouseDown = this.onRotateMouseDown.bind(this);
+        this.onRotateMouseUp = this.onRotateMouseUp.bind(this);
+        this.onRotateMouseMove = this.onRotateMouseMove.bind(this);
     }
 
     connectedCallback(){
@@ -235,6 +248,12 @@ class Halo extends HTMLElement {
                 this.resizer.style.visibility = 'hidden';
             }
 
+            // Rotate button
+            this.rotater = this.shadowRoot.getElementById('halo-rotate');
+            this.rotater.addEventListener('mousedown', this.onRotateMouseDown);
+            if(!this.targetElement.wantsHaloRotate){
+                this.rotater.style.visibility = 'hidden';
+            }
             // Delete button
             this.deleter = this.shadowRoot.getElementById('halo-delete');
             this.deleter.addEventListener('click', this.targetElement.onHaloDelete);
@@ -320,6 +339,24 @@ class Halo extends HTMLElement {
 
     onResizeMouseMove(event){
         this.targetElement.onHaloResize(
+            event.movementX,
+            event.movementY
+        );
+    }
+
+    onRotateMouseDown(event){
+        event.stopPropagation();
+        document.addEventListener('mousemove', this.onRotateMouseMove);
+        document.addEventListener('mouseup', this.onRotateMouseUp);
+    }
+
+    onRotateMouseUp(event){
+        document.removeEventListener('mousemove', this.onRotateMouseMove);
+        document.removeEventListener('mouseup', this.onRotateMouseUp);
+    }
+
+    onRotateMouseMove(event){
+        this.targetElement.onHaloRotate(
             event.movementX,
             event.movementY
         );

--- a/js/objects/views/ImageView.js
+++ b/js/objects/views/ImageView.js
@@ -244,6 +244,13 @@ class ImageView extends PartView {
         // We resize the wrapped svg or img instead
         // and have the outer component simply react to
         // the change.
+        // If the part is rotated this will throw off the bounding rectangle
+        // browser calcualtion. So the hack here is to rotate the part to 0
+        // (if necessary) do the calculations and then rotate it back
+        let angle = this.model.partProperties.getPropertyNamed(this.model, "rotate");
+        if(angle){
+            this.model.partProperties.setPropertyNamed(this.model, "rotate", 0);
+        }
         let wrappedImage = this._shadowRoot.querySelector('.currently-wrapped');
         let rect = wrappedImage.getBoundingClientRect();
         let newWidth, newHeight;
@@ -269,6 +276,10 @@ class ImageView extends PartView {
                 'height',
                 newHeight
             );
+        }
+        // reset the rotate angle to the original (if necessary)
+        if(angle){
+            this.model.partProperties.setPropertyNamed(this.model, "rotate", angle);
         }
     }
 

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -30,6 +30,7 @@ class PartView extends HTMLElement {
 
         // Halo settings. All are on by default
         this.wantsHaloResize = true;
+        this.wantsHaloRotate = true;
         this.wantsHaloScriptEdit = true;
         this.wantsHaloEdit = true;
         this.wantsHaloDelete = true;
@@ -80,6 +81,7 @@ class PartView extends HTMLElement {
         this.onHaloOpenEditor = this.onHaloOpenEditor.bind(this);
         this.onHaloOpenScriptEditor = this.onHaloOpenScriptEditor.bind(this);
         this.onHaloResize = this.onHaloResize.bind(this);
+        this.onHaloRotate = this.onHaloRotate.bind(this);
         this.onHaloPaste = this.onHaloPaste.bind(this);
         this.onHaloCopy = this.onHaloCopy.bind(this);
         this.onHaloTarget = this.onHaloTarget.bind(this);
@@ -641,6 +643,31 @@ class PartView extends HTMLElement {
         }
         this.model.partProperties.setPropertyNamed(this.model, "width", newWidth);
         this.model.partProperties.setPropertyNamed(this.model, "height", newHeight);
+    }
+
+    onHaloRotate(movementX, movementY){
+        // Default implementation on what to do during
+        // halo button rotate opertations. Subclasses
+        // can override for custom behavior.
+        // Default is to update the View component's
+        // rotate style property directly.
+        if(movementX || movementY){
+            let currentAngle = this.model.partProperties.getPropertyNamed(this.model, "rotate");
+            let rect = this.getBoundingClientRect();
+            if(!currentAngle){
+                currentAngle = 0;
+            }
+            let theta1 = Math.atan((rect.height/2)/(rect.width/2));
+            let theta2 = Math.atan((rect.height/2 + movementY)/(rect.width/2 + movementX));
+            let changeAngle = Math.abs((theta2 - theta1)*180/Math.PI);
+            let newAngle = (currentAngle + changeAngle) % 360;
+            if(newAngle < 0){
+                newAngle = 360 + newAngle;
+            }
+            if(newAngle){
+                this.model.partProperties.setPropertyNamed(this.model, "rotate", newAngle);
+            }
+        }
     }
 
     onHaloCopy(){

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -627,6 +627,13 @@ class PartView extends HTMLElement {
         // can override for custom behavior.
         // Default is to update the View component's
         // width and height style properties directly.
+        // If the part is rotated this will throw off the bounding rectangle
+        // browser calcualtion. So the hack here is to rotate the part to 0
+        // (if necessary) do the calculations and then rotate it back
+        let angle = this.model.partProperties.getPropertyNamed(this.model, "rotate");
+        if(angle){
+            this.model.partProperties.setPropertyNamed(this.model, "rotate", 0);
+        }
         let rect = this.getBoundingClientRect();
         let newWidth, newHeight;
         if(this.preserveAspectOnResize){
@@ -643,6 +650,10 @@ class PartView extends HTMLElement {
         }
         this.model.partProperties.setPropertyNamed(this.model, "width", newWidth);
         this.model.partProperties.setPropertyNamed(this.model, "height", newHeight);
+        // reset the rotate angle to the original (if necessary)
+        if(angle){
+            this.model.partProperties.setPropertyNamed(this.model, "rotate", angle);
+        }
     }
 
     onHaloRotate(movementX, movementY){


### PR DESCRIPTION
### Main Points ###

This PR adds a halo rotate icon. I found it a pain to set the rotate prop by hand every time. At the moment this is a pretty simple implementation, i.e. it only turns clockwise and does not include things like velocity (it's actually kind of a pain to implement this properly, in both directions, and so I let it be but it's also possible I am being an idiot...)

In addition, there was a pretty nasty bug which would exponentially blow up the part height/width on resize if the part of rotated. The reason for this is due to how `.getBoundingRectangle()` is implemented. I added a [hack](https://github.com/dkrasner/Simpletalk/compare/daniel-halo-rotate?expand=1#diff-f8a644f39713f7d56b51b944769a8733fceb081884704c2a73b93c232b554560R630) that sets the rotate prop to 0 (if needed), does the calc and then sets it back. 