### PR TITLE
Go to

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -840,18 +840,22 @@ System._commandHandlers['go to direction'] = function(senders, directive, object
     }
 };
 
-System._commandHandlers['go to reference'] = function(senders, objectName, referenceId){
-    switch(objectName) {
+System._commandHandlers['go to'] = function(senders, id){
+    let model = this.partsById[id];
+    if(!model){
+        alert(`"go to" target not found`);
+    }
+    switch(model.type) {
         case 'card':
-            this.goToCardById(referenceId);
+            this.goToCardById(id);
             break;
 
         case 'stack':
-            this.goToStackById(referenceId);
+            this.goToStackById(id);
             break;
 
         default:
-            alert(`"go to" not implemented for ${objectName}`);
+            alert(`"go to" not implemented for ${model.type}`);
 
     }
 };

--- a/js/objects/parts/Stack.js
+++ b/js/objects/parts/Stack.js
@@ -80,14 +80,18 @@ class Stack extends Part {
     goToCardById(anId){
         let currentCardId = this.currentCardId;
         let currentCard = this.currentCard;
-        let cards = this.subparts.filter(subpart => {
-            return subpart.type == 'card';
+        let cards = Object.values(window.System.partsById).filter((part) => {
+            return part.type == "card";
         });
         let nextCard = cards.find(card => {
             return card.id == anId;
         });
         if(!nextCard){
-            throw new Error(`The card id: ${anId} cant be found on this stack`);
+            throw new Error(`The card id: ${anId} cant be found stack`);
+        }
+        // if the card is not on this stack we should go to the corresponding stack
+        if(nextCard._owner != this){
+            this._owner.goToStackById(nextCard._owner.id);
         }
         this.partProperties.setPropertyNamed(
             this,

--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -98,19 +98,24 @@ const errorHandler = {
                     this._openScriptEditor(originalSender.id);
                     scriptEditor = window.System.findScriptEditorByTargetId(originalSender.id);
                 }
-                target = scriptEditor.model;
-            }
-            let textLines = text.split("\n");
-            // offending command text line with an error marker
-            for(let i = 0; i < textLines.length; i++){
-                let line = textLines[i];
-                if(line.match(regex)){
-                    textLines[i] = line += ` --<<<[MessageNotUnderstood: command; commandName: "${commandName}"]`;
+                if(scriptEditor){
+                    target = scriptEditor.model;
                 }
             }
-            text = textLines.join("\n");
-            target.partProperties.setPropertyNamed(target, "text", text);
+            // TODO Sort this out
+            if(target){
+                let textLines = text.split("\n");
+                // offending command text line with an error marker
+                for(let i = 0; i < textLines.length; i++){
+                    let line = textLines[i];
+                    if(line.match(regex)){
+                        textLines[i] = line += ` --<<<[MessageNotUnderstood: command; commandName: "${commandName}"]`;
+                    }
+                }
+                text = textLines.join("\n");
+                target.partProperties.setPropertyNamed(target, "text", text);
 
+            }
             // finally open the debugger (or current version thereof)
             // NOTE: this is a bit dangerous, b/c if the System doesn't
             // handle the `openDebugger` command anywhere it will throw

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -153,14 +153,14 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             return msg;
         },
 
-        Command_goToByReference: function(goToLiteral, systemObject, objectId){
-            let args = [];
-            args.push(systemObject.sourceString);
-            args.push(objectId.sourceString);
+        Command_goToByObjectSpecifier: function(goToLiteral, objectSpecifier){
+            let args = [
+                objectSpecifier.interpret() // id of the object
+            ];
 
             let msg = {
                 type: "command",
-                commandName: "go to reference",
+                commandName: "go to",
                 args: args
             };
             return msg;

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -226,7 +226,7 @@ SimpleTalk {
 
     Command (a command statement)
       = "go to" ("next" | "previous") systemObject --goToDirection
-      | "go to" systemObject objectId --goToByReference
+      | "go to" ObjectSpecifier --goToByObjectSpecifier
       | "answer" (Conditional | Expression) --answer
       | "delete" ObjectSpecifier --deleteModel
       | "delete" "property" stringLiteral "from"? ObjectSpecifier? --deleteProperty

--- a/js/ohm/tests/test-core-commands.js
+++ b/js/ohm/tests/test-core-commands.js
@@ -50,10 +50,22 @@ describe("Core commands", () => {
                 semanticMatchTest(s, "Statement");
             });
         });
-        it ("go to by reference", () => {
-            const s = "go to card 42";
+        it ("go to by index", () => {
+            const s = "go to card 2";
             semanticMatchTest(s, "Command");
-            semanticMatchTest(s, "Command_goToByReference");
+            semanticMatchTest(s, "Command_goToByObjectSpecifier");
+            semanticMatchTest(s, "Statement");
+        });
+        it ("go to by id", () => {
+            const s = "go to stack id 2";
+            semanticMatchTest(s, "Command");
+            semanticMatchTest(s, "Command_goToByObjectSpecifier");
+            semanticMatchTest(s, "Statement");
+        });
+        it ("go to by name", () => {
+            const s = 'go to stack "cool stack"';
+            semanticMatchTest(s, "Command");
+            semanticMatchTest(s, "Command_goToByObjectSpecifier");
             semanticMatchTest(s, "Statement");
         });
         it ("Bad go to: invalid object", () => {

--- a/js/ohm/tests/test-repeat-grammar.js
+++ b/js/ohm/tests/test-repeat-grammar.js
@@ -108,7 +108,6 @@ describe("RepeatBlock tests", () => {
         let str = [
             "repeat until myVariable <= 20.5",
             "doSomething myVariable",
-            "go to card myVariable",
             "end repeat"
         ].join("\n");
         semanticMatchTest(str, "RepeatBlock");
@@ -117,7 +116,6 @@ describe("RepeatBlock tests", () => {
         let str = [
             "repeat while myVariable >= 20.5",
             "doSomething myVariable",
-            "go to card myVariable",
             "end repeat"
         ].join("\n");
         semanticMatchTest(str, "RepeatBlock");
@@ -126,7 +124,6 @@ describe("RepeatBlock tests", () => {
         let str = [
             "repeat with myNum = 0 to 6",
             "doSomething myVariable",
-            "go to card myVariable",
             "end repeat"
         ].join("\n");
         semanticMatchTest(str, "RepeatBlock");
@@ -135,7 +132,6 @@ describe("RepeatBlock tests", () => {
         let str = [
             "repeat",
             "doSomething myVariable",
-            "go to card myVariable",
             "end repeat"
         ].join("\n");
         semanticMatchTest(str, "RepeatBlock");


### PR DESCRIPTION
### Main Points ###

Our "go to objectType objectId" by reference grammar and semantics was not consistent with the rest of the language. For example, something like `go to card 2` would mean go to card with id=2 whereas in all other command cases `... card 2` would specify the second card. I figured we could kick this down the line, which we did, but in making our "parts" documentation stack I found it really annoying, ugly (since our ids are not pretty looking) and error prone (since these can change as you add remove cards, stacks). 

For example, I continually wanted to have navigation buttons with scripts like

```
on click
     go to card "Editing Parts"
end click
```
or

```
on click
    go to card "list layout" of stack "layouts"
end click
```

Moreover, our implementation had a bug `Stack.goToCardById()` assumed that the card was [on the same stack](https://github.com/dkrasner/Simpletalk/blob/master/js/objects/parts/Stack.js#L83) which kind of defeats the point of a unique id. We simply didn't see this b/c by the time we did enough navigation with multiple stacks we used the navigator....

I know this might be a breaking change for some of the stacks out there, but I assume it's pretty minor at this point.

(I also fixed a minor bug which was causing an error handling test to fail in master; the whole error handler should be re-implemented but that is another story.)