### PR TITLE
adding go to website

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -846,18 +846,22 @@ System._commandHandlers['go to'] = function(senders, id){
         alert(`"go to" target not found`);
     }
     switch(model.type) {
-        case 'card':
-            this.goToCardById(id);
-            break;
+    case 'card':
+        this.goToCardById(id);
+        break;
 
-        case 'stack':
-            this.goToStackById(id);
-            break;
+    case 'stack':
+        this.goToStackById(id);
+        break;
 
-        default:
-            alert(`"go to" not implemented for ${model.type}`);
+    default:
+        alert(`"go to" not implemented for ${model.type}`);
 
     }
+};
+
+System._commandHandlers['go to website'] = function(senders, url){
+    window.location.href = url;
 };
 
 //Import a world, i.e. its stacks from another source

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -166,6 +166,19 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             return msg;
         },
 
+        Command_goToWebsite: function(goToLiteral, websiteLiteral, url){
+            let args = [
+                url.interpret()
+            ];
+
+            let msg = {
+                type: "command",
+                commandName: "go to website",
+                args: args
+            };
+            return msg;
+        },
+
         Command_addProperty: function(addLiteral, propertyLiteral, propNameAsLiteral, toLiteral, systemObject){
             let specifiedObjectId = systemObject.interpret()[0] || null;
             let args = [

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -227,6 +227,7 @@ SimpleTalk {
     Command (a command statement)
       = "go to" ("next" | "previous") systemObject --goToDirection
       | "go to" ObjectSpecifier --goToByObjectSpecifier
+      | "go to" "website" stringLiteral --goToWebsite
       | "answer" (Conditional | Expression) --answer
       | "delete" ObjectSpecifier --deleteModel
       | "delete" "property" stringLiteral "from"? ObjectSpecifier? --deleteProperty

--- a/js/ohm/tests/test-core-commands.js
+++ b/js/ohm/tests/test-core-commands.js
@@ -68,6 +68,12 @@ describe("Core commands", () => {
             semanticMatchTest(s, "Command_goToByObjectSpecifier");
             semanticMatchTest(s, "Statement");
         });
+        it ("go to website", () => {
+            const s = 'go to website "http//coolsite.awesome"';
+            semanticMatchTest(s, "Command");
+            semanticMatchTest(s, "Command_goToWebsite");
+            semanticMatchTest(s, "Statement");
+        });
         it ("Bad go to: invalid object", () => {
             const s = "go to card";
             semanticMatchFailTest(s, "Command");


### PR DESCRIPTION
### Main Points ###
We now have a `go to website "[url]"` which loads the given url in the _same_ tab. 

Note: the proper way to do this is to use the `window.open` API as opposed to [setting](https://github.com/dkrasner/Simpletalk/compare/daniel-goto-website?expand=1#diff-27807be337857d016752d52609f4312048ef006984f0d2e108676823ffe892f6R864) the location directly. However, there is no guarantee that a new tab, or window, will open. This depends on browsers and personal settings (popup blockers etc). I could have added a check to see if `window.open` returns null, i.e. fail, and then done the direction location settings, but then I figured maybe it is best to stick to consistent behavior - thoughts?