### PR TITLE
adding propertyChanged message sent for field text

### DIFF
--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -368,6 +368,9 @@ class FieldView extends PartView {
             event.target.innerHTML,
             false // do not notify
         );
+        // Since we update the 'text' property without notification, the part/model
+        // is not sent the "propertyChanged" message so we do so manually
+        this.model.propertyChanged("text", event.target.innerText);
         // if there is a target and range set then send the target an update message
         let target = this.model.partProperties.getPropertyNamed(this.model, 'target');
         if(target){


### PR DESCRIPTION
### Main Points ###

Due to the overly complicated way we deal with setting the `text` and `html` property in field, where we don't notify when the former is changed, we didn't have a `propertyChanged` "text" message being sent to the part. 