### PR TITLE
Adding smart resizing to ContextMenu and any submenus

### DIFF
--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -899,11 +899,10 @@ class PartView extends HTMLElement {
 
     openContextMenuAt(x, y){
         let menuEl = document.createElement('st-context-menu');
-        let worldView = document.querySelector('[part-id="world"]');
         menuEl.render(this.model);
         menuEl.style.left = `${x}px`;
         menuEl.style.top = `${y}px`;
-        worldView.append(menuEl);
+        document.body.append(menuEl);
 
         // Ensure that the menu is completely
         // within the current view. If not (meaning

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -904,6 +904,12 @@ class PartView extends HTMLElement {
         menuEl.style.left = `${x}px`;
         menuEl.style.top = `${y}px`;
         worldView.append(menuEl);
+
+        // Ensure that the menu is completely
+        // within the current view. If not (meaning
+        // it is clipped), then adjust so it is
+        // completely in the view.
+        menuEl.adjustToClientView();
     }
 
     closeContextMenu(){

--- a/js/objects/views/contextmenu/ContextMenu.js
+++ b/js/objects/views/contextmenu/ContextMenu.js
@@ -83,6 +83,7 @@ class ContextMenu extends HTMLElement {
         this.addListItem = this.addListItem.bind(this);
         this.addSpacer = this.addSpacer.bind(this);
         this.hideHeader = this.hideHeader.bind(this);
+        this.adjustToClientView = this.adjustToClientView.bind(this);
     }
 
     render(aModel){
@@ -373,6 +374,39 @@ class ContextMenu extends HTMLElement {
     hideHeader(){
         let headerEl = this._shadowRoot.querySelector('header');
         headerEl.style.display = "none";
+    }
+
+    adjustToClientView(){
+        let rect = this.getBoundingClientRect();
+        let padding = 10;
+        let viewportWidth = document.documentElement.clientWidth;
+        let viewportHeight = document.documentElement.clientHeight;
+        let bottomDiff = (rect.bottom + padding) - viewportHeight;
+        let rightDiff = (rect.right + padding) - viewportWidth;
+        if(bottomDiff > 0){
+            this.style.top = `${(rect.top - bottomDiff)}px`;
+
+            // Reposition any hidden submenus, so they open
+            // above
+            Array.from(this.children).filter(childEl => {
+                return childEl.children.length > 0;
+            }).forEach(itemWithSubmenu => {
+                let container = itemWithSubmenu._shadowRoot.querySelector('.submenu-area');
+                container.style.top = `${(-1 * itemWithSubmenu.getBoundingClientRect().height)}px`;
+            });
+        }
+        if(rightDiff > 0){
+            this.style.left = `${rect.left - rightDiff}px`;
+
+            // Reposition any hidden submenus, so they open
+            // to the left (instead of right)
+            Array.from(this.children).filter(childEl => {
+                return childEl.children.length > 0;
+            }).forEach(itemWithSubmenu => {
+                let container = itemWithSubmenu._shadowRoot.querySelector('.submenu-area');
+                container.style.left = `${(-1 * itemWithSubmenu.getBoundingClientRect().width)}px`;
+            });
+        }
     }
 };
 

--- a/js/objects/views/contextmenu/ContextMenuItem.js
+++ b/js/objects/views/contextmenu/ContextMenuItem.js
@@ -56,8 +56,7 @@ class ContextMenuItem extends HTMLElement {
 
     showCaret(){
         let caretEl = this._shadowRoot.querySelector('.caret');
-        caretEl.classList.remove('hidden');
-        
+        caretEl.classList.remove('hidden');    
     }
 };
 


### PR DESCRIPTION
## What ##
This PR ensures that the ContextMenu and any "revealed" submenus will not
render outside of the bounds of the browser window view (ie, be
clipped and therefore only partially visible)
  
## Closes ##
Issue #88 