### PR TITLE
Arrow Key events and the `arrowKey` command

### DIFF
--- a/js/objects/views/WorldView.js
+++ b/js/objects/views/WorldView.js
@@ -12,6 +12,12 @@ import PartView from './PartView.js';
 
 const templateString = `<slot></slot>`;
 
+const NODES_TO_IGNORE_WHEN_ARROW_KEY = [
+    'TEXTAREA',
+    'INPUT',
+    'ST_FIELD'
+];
+
 class WorldView extends PartView {
     constructor(){
         super();
@@ -21,6 +27,7 @@ class WorldView extends PartView {
         // module as formatted text
         const template = document.createElement('template');
         template.innerHTML = templateString;
+        
         this._shadowRoot = this.attachShadow({mode: 'open'});
         this._shadowRoot.appendChild(
             template.content.cloneNode(true)
@@ -84,6 +91,26 @@ class WorldView extends PartView {
         if(event.altKey && event.ctrlKey && event.code == "Space"){
             let navigator = document.querySelector('st-navigator');
             navigator.toggle();
+        } else {
+            // Bind arrow key events if and only if
+            // the focus is not in any kind of text input.
+            // We send the arrowKey command to the current card
+            if(event.code.startsWith('Arrow')){
+                if(!NODES_TO_IGNORE_WHEN_ARROW_KEY.includes(event.target.nodeName)){
+                    this.model.sendMessage({
+                        type: 'command',
+                        commandName: 'arrowKey',
+                        args: [
+                            // First arg is the direction
+                            event.code.split('Arrow')[1].toLowerCase(),
+                            event.ctrlKey,
+                            event.altKey,
+                            event.shiftKey
+                        ],
+                        shouldIgnore: true
+                    }, this.model.currentStack.currentCard);
+                }
+            }
         }
     }
 

--- a/js/objects/views/WorldView.js
+++ b/js/objects/views/WorldView.js
@@ -15,7 +15,7 @@ const templateString = `<slot></slot>`;
 const NODES_TO_IGNORE_WHEN_ARROW_KEY = [
     'TEXTAREA',
     'INPUT',
-    'ST_FIELD'
+    'ST-FIELD'
 ];
 
 class WorldView extends PartView {
@@ -96,7 +96,7 @@ class WorldView extends PartView {
             // the focus is not in any kind of text input.
             // We send the arrowKey command to the current card
             if(event.code.startsWith('Arrow')){
-                if(!NODES_TO_IGNORE_WHEN_ARROW_KEY.includes(event.target.nodeName)){
+                if(!NODES_TO_IGNORE_WHEN_ARROW_KEY.includes(document.activeElement.nodeName)){
                     this.model.sendMessage({
                         type: 'command',
                         commandName: 'arrowKey',

--- a/js/objects/views/contextmenu/ContextMenu.js
+++ b/js/objects/views/contextmenu/ContextMenu.js
@@ -113,6 +113,9 @@ class ContextMenu extends HTMLElement {
         itemEl.textContent = label;
         itemEl.classList.add('context-menu-item');
         itemEl.addEventListener('click', callback);
+        itemEl.addEventListener('click', () => {
+            this.remove();
+        });
         if(submenu){
             submenu.classList.add('context-submenu', 'submenu-hidden');
             submenu.setAttribute('slot', 'submenu');


### PR DESCRIPTION
## What ##
This PR implements built-in sending of a command called `arrowKey` that is triggered whenever any of the keyboard arrow keys are pressed.
  
## Implementation ##
The listener for arrow key events is bound in the `WorldView` [here](https://github.com/dkrasner/Simpletalk/blob/eric-arrow-keys/js/objects/views/WorldView.js#L98).
  
When an arrow key is pressed, the command `arrowKey` will be sent to the **current card**, along with the following ordered arguments:
1. the `direction` as a string. Will be "up" "right" "down" or "left"
2. a boolean indicating if the control key was down
3. a boolean indicating if the alt key was down
4. a boolean indicating if the shift key was down
  
Note that there is an important case where the message will *not* be sent. That is if the browser's focus is in some kind of text input field (we want to be able to navigate text cursors).
  
## Trying it out ##
To try this out, simply load up a stack that has multiple cards. Edit that Stack's script and add the following:
```simpletalk
on arrowKey direction
    if direction is "right" then go to next card
    if direction is "left" then go to previous card
end arrowKey
```
  
Once saved, the left and right arrow keys should allow you to navigate between cards in the stack.
  
## Special Notes ##
Issue #93 is currently preventing us from compiling scripts on the World, which is where we might like to implement the arrowkey navigation when making presentations. For now we can just do it at the stack level in order to demonstrate that it works.