### PR TITLE
fixing bug where objectId specifier excluded 'world'

### DIFF
--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -244,8 +244,12 @@ SimpleTalk {
     CommentLines
       = (comment lineTerminator)+
 
-    systemObject (system object such as card, stack etc)
-      = ("w" | "W") "orld" | ("a" | "A") "rea" | ("b"| "B") "ackground" | ("b" | "B") "utton" | ("c" | "C") "ard" | ("f" | "F") "ield" | ("s" | "S") "tack" | ("w" | "W") "indow" | ("d" | "D") "rawing" | ("i" | "I") "mage" | ("a" | "A") "udio" | ("r" | "R") "esource" | ("b" | "B") "rowser"
+    worldObject = ("w" | "W") "orld"
+    
+    basicObject (system object such as card, stack etc excluding world)
+      = ("a" | "A") "rea" | ("b"| "B") "ackground" | ("b" | "B") "utton" | ("c" | "C") "ard" | ("f" | "F") "ield" | ("s" | "S") "tack" | ("w" | "W") "indow" | ("d" | "D") "rawing" | ("i" | "I") "mage" | ("a" | "A") "udio" | ("r" | "R") "esource" | ("b" | "B") "rowser"
+
+    systemObject = worldObject | basicObject
 
     // TODO do we want to restrict message names (start with lowercase etc)?
     // Note: we prevent keyword overloading
@@ -276,7 +280,7 @@ SimpleTalk {
       | "seventh" | "eighth" | "ninth" | "tenth" | "last"
 
     objectId (an identifier of an object, string, numeric or mixed)
-      = ~systemObject (letter | digit)+
+      = ~basicObject (worldObject | (letter | digit)+)
 
 
     // Helper utilities

--- a/js/ohm/tests/test-object-specifier-grammar.js
+++ b/js/ohm/tests/test-object-specifier-grammar.js
@@ -62,6 +62,20 @@ describe("Terminal Specifier Tests", () => {
             let str = `part id 2.3`;
             semanticMatchFailTest(str, 'TerminalSpecifier_partById');
         });
+        it("Can parse a part by an alphanumeric id", () => {
+            let str = `part id 24ab22`;
+            semanticMatchTest(str, 'TerminalSpecifier_partById');
+        });
+        it("Can parse a part with 'world' id", () => {
+            let str = `part id world`;
+            semanticMatchTest(str, 'TerminalSpecifier_partById');
+        });
+        it("Cannot parse a part by a basic object (stack, card etc) id", () => {
+            partTypes.forEach(partName => {
+                let str = `part id ${partName}`;
+                semanticMatchFailTest(str, 'TerminalSpecifier_partById');
+            });
+        });
     });
     it('currentSystemObject (card and stack only)', () => {
         let valid = ["card", "stack"];


### PR DESCRIPTION
### Main Points ###

The `objectId` specifier was [excluding](https://github.com/dkrasner/Simpletalk/compare/danile-issue-93?expand=1#diff-f189d2a29e6e2a0f4a8cd3a2f8c72779e92347a335215074c196e9bec06c5a80L279) all `systemObject`s which meant "world." Subsequently all scripts which referenced world by its id failed parsing, and since our script editor "save" button works by invoking the target ("part id world") we couldn't add scripts there. 

closes issue #93 

@darth-cheney 

you can now add your 
```
on arrowKey direction
    if direction is "right" then go to next card
    if direction is "left" then go to previous card
end arrowKey
```
script to world and it all works fine 