### PR TITLE
Debugger and grammar windows

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -1072,6 +1072,86 @@ System._commandHandlers['openDebugger'] = function(senders, partId, type, name){
     });
 };
 
+System._commandHandlers['openGrammar'] = function(senders, partId, ruleName){
+    // first make sure that there are no grammar windows open already
+    let windows = Object.values(window.System.partsById).filter((part) => {return part.name == "Window";});
+    let grammarWindows = windows.filter((window) => {
+        return window.partProperties.getPropertyNamed(window, "name") == "Simpletalk Grammar";
+    });
+    if(grammarWindows.length){
+        return;
+    }
+    let target = this.partsById[partId];
+    // Create the Field model and attach to current card
+    let currentCard = this.getCurrentCardModel();
+    let windowModel = this.newModel('window', currentCard.id);
+    let areaModel = this.newModel('area', windowModel.id);
+    // name the window and setup basic layout
+    windowModel.partProperties.setPropertyNamed(
+        windowModel,
+        'name',
+        "Simpletalk Grammar"
+    );
+    windowModel.partProperties.setPropertyNamed(
+        windowModel,
+        'title',
+        "Simpletalk Grammar"
+    );
+    windowModel.partProperties.setPropertyNamed(
+        windowModel,
+        'width',
+        400
+    );
+    windowModel.partProperties.setPropertyNamed(
+        windowModel,
+        'height',
+        200
+    );
+    areaModel.partProperties.setPropertyNamed(
+        areaModel,
+        'layout',
+        "list"
+    );
+    areaModel.partProperties.setPropertyNamed(
+        areaModel,
+        'list-direction',
+        "column"
+    );
+    areaModel.partProperties.setPropertyNamed(
+        areaModel,
+        'width',
+        "fill"
+    );
+    areaModel.partProperties.setPropertyNamed(
+        areaModel,
+        'height',
+        "fill"
+    );
+    // add the grammar text
+    let text = System.grammar.source.sourceString;
+    let fieldModel = this.newModel('field', areaModel.id);
+    fieldModel.partProperties.setPropertyNamed(
+        fieldModel,
+        'text',
+        text
+    );
+    fieldModel.partProperties.setPropertyNamed(
+        fieldModel,
+        'editable',
+        false
+    );
+    fieldModel.partProperties.setPropertyNamed(
+        fieldModel,
+        'width',
+        "fill"
+    );
+    fieldModel.partProperties.setPropertyNamed(
+        fieldModel,
+        'height',
+        "fill"
+    );
+};
+
 System._commandHandlers['saveHTML'] = function(senders){
     // Stop hand recognition if it's running.
     let handRecognitionOriginallyRunning = handInterface.handDetectionRunning;

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -989,26 +989,87 @@ System._commandHandlers['SimpleTalk'] = function(senders){
     return System.grammar.source.sourceString;
 }
 
-System._commandHandlers['openDebugger'] = function(senders, partId){
+System._commandHandlers['openDebugger'] = function(senders, partId, type, name){
     let target = this.partsById[partId];
     // Create the Field model and attach to current card
     let currentCard = this.getCurrentCardModel();
-    let fieldModel = this.newModel('field', currentCard.id);
-    let text = `Available Commands for ${target.name} (id ${target.id})\n\n`;
-    Object.keys(target.commandHandlerRegistry).forEach((name) =>{
-        let info = target.commandHandlerRegistry[name];
-        text += `${name}: ${JSON.stringify(info)}\n`;
+    let windowModel = this.newModel('window', currentCard.id);
+    let areaModel = this.newModel('area', windowModel.id);
+    // name the window and setup basic layout
+    windowModel.partProperties.setPropertyNamed(
+        windowModel,
+        'name',
+        "debugger"
+    );
+    windowModel.partProperties.setPropertyNamed(
+        windowModel,
+        'title',
+        `Message Not Understood : ${name}`
+    );
+    windowModel.partProperties.setPropertyNamed(
+        windowModel,
+        'width',
+        400
+    );
+    windowModel.partProperties.setPropertyNamed(
+        windowModel,
+        'height',
+        200
+    );
+    areaModel.partProperties.setPropertyNamed(
+        areaModel,
+        'layout',
+        "list"
+    );
+    areaModel.partProperties.setPropertyNamed(
+        areaModel,
+        'list-direction',
+        "column"
+    );
+    areaModel.partProperties.setPropertyNamed(
+        areaModel,
+        'width',
+        "fill"
+    );
+    areaModel.partProperties.setPropertyNamed(
+        areaModel,
+        'height',
+        "fill"
+    );
+    areaModel.partProperties.setPropertyNamed(
+        areaModel,
+        'allow-scrolling',
+        true
+    );
+    // fill in all the available commands for the given part
+    Object.keys(target.commandHandlerRegistry).forEach((key) =>{
+        let text = key;
+        let isPrivate = target.commandHandlerRegistry[key].private;
+        if(isPrivate){
+            text += " (private)";
+        }
+        let fieldModel = this.newModel('field', areaModel.id);
+        fieldModel.partProperties.setPropertyNamed(
+            fieldModel,
+            'text',
+            text
+        );
+        fieldModel.partProperties.setPropertyNamed(
+            fieldModel,
+            'editable',
+            false
+        );
+        fieldModel.partProperties.setPropertyNamed(
+            fieldModel,
+            'width',
+            "fill"
+        );
+        fieldModel.partProperties.setPropertyNamed(
+            fieldModel,
+            'height',
+            20
+        );
     });
-    fieldModel.partProperties.setPropertyNamed(
-        fieldModel,
-        'text',
-        text
-    );
-    fieldModel.partProperties.setPropertyNamed(
-        fieldModel,
-        'editable',
-        false
-    );
 };
 
 System._commandHandlers['saveHTML'] = function(senders){

--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -147,33 +147,12 @@ const errorHandler = {
 
     _openGrammar: function(partId, ruleName){
         let target = window.System.partsById[partId];
-        let statementLines = [
-            'if there is not a field "SimpleTalk" of current card',
-            'then',
-            'add field "SimpleTalk" to current card',
-            'tell field "SimpleTalk" of current card to set "editable" to false',
-            'SimpleTalk',
-            'tell field "SimpleTalk"of current card to set "text" to it',
-            'end if'
-        ];
-        let script = `on doIt\n   ${statementLines.join('\n')}\nend doIt`;
-        target.sendMessage(
-            {
-                type: "compile",
-                codeString: script,
-                targetId: target.id
-            },
-            target
-        );
-        target.sendMessage(
-            {
-                type: "command",
-                commandName: "doIt",
-                args: [],
-                shouldIgnore: true // Should ignore if System DNU
-            },
-            target
-        );
+        let msg = {
+            type: "command",
+            "commandName": "openGrammar",
+            args: [partId, ruleName]
+        };
+        target.sendMessage(msg, target);
     },
 
     // At the moment this simply opens a st-window st-field with

--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -121,7 +121,7 @@ const errorHandler = {
             // handle the `openDebugger` command anywhere it will throw
             // a MNU error, which will then invoke this handler cuasing
             // an infinite loop!
-            this._openDebugger(originalSender.id);
+            this._openDebugger(originalSender.id, offendingMessage.type, offendingMessage.commandName);
         }
     },
 
@@ -178,12 +178,12 @@ const errorHandler = {
 
     // At the moment this simply opens a st-window st-field with
     // information about the available commands for said parts
-    _openDebugger: function(partId){
+    _openDebugger: function(partId, type, name){
         let target = window.System.partsById[partId];
         let msg = {
             type: "command",
             "commandName": "openDebugger",
-            args: [partId]
+            args: [partId, type, name]
         };
         target.sendMessage(msg, target);
     }


### PR DESCRIPTION
### Main Points ###

This PR gives our debugger and grammar display a little more structure to work with and frees them from layout on the current card (which can make them appear and be locked into weird locations on the screen). 

Instead of adding a hidden window (for both debugger and grammar), then setting hide to false and populating as needed, I decided to let system construct the various necessary parts. In the future, once we know a little more of what we want we can change that. Also at the moment the debugger is pretty trivial, but I can imagine pretty easily changing the fields with the available command names to be buttons where if you click on it a dialogue area appears where you can send the corresponding command to the original part in question (for that we need arg info for the commands but that should also be more structured - maybe a command should really be a special "non-display" part?...) . And so on....

Also it looks better than before, if by a little, which is plus. 

Closes issue #69 