### PR TITLE
Fixing Editor Messenger

### DIFF
--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -103,7 +103,7 @@ const errorHandler = {
                 }
             }
             // TODO Sort this out
-            if(target){
+            if(target && text){
                 let textLines = text.split("\n");
                 // offending command text line with an error marker
                 for(let i = 0; i < textLines.length; i++){

--- a/js/objects/views/editors/EditorMessenger.js
+++ b/js/objects/views/editors/EditorMessenger.js
@@ -1,4 +1,4 @@
-
+import interpreterSemantics from '../../../ohm/interpreter-semantics.js';
 
 // PREAMBLE
 const templateString = `
@@ -44,7 +44,7 @@ class EditorMessenger extends HTMLElement {
         if(this.isConnected){
             this.sendButton = this._shadowRoot.querySelector('button');
             this.sendButton.addEventListener('click', this.sendMessageFromText);
-        
+
             this.messageField = this._shadowRoot.querySelector('textarea');
             this.messageField.addEventListener('input', this.onMessageFieldInput);
         }
@@ -57,7 +57,7 @@ class EditorMessenger extends HTMLElement {
 
     render(aModel){
         this.model = aModel;
-        
+
         let partTypeLabel = this._shadowRoot.querySelector('h3 > span');
         partTypeLabel.textContent = this.model.type;
     }
@@ -70,6 +70,15 @@ class EditorMessenger extends HTMLElement {
         let text = this.messageField.value + '\n';
         let parsed = window.System.grammar.match(text, 'StatementList');
         if(parsed.succeeded()){
+            // it's possible that no script has been compiled on this part
+            // and hence no semantics exist
+            if(!this.model_semantics){
+                this.model._semantics = window.System.grammar.createSemantics();
+                this.model._semantics.addOperation(
+                    'interpret',
+                    interpreterSemantics(this.model, window.System)
+                );
+            }
             this.model._semantics(parsed).interpret();
         }
     }

--- a/js/objects/views/editors/EditorMessenger.js
+++ b/js/objects/views/editors/EditorMessenger.js
@@ -67,19 +67,11 @@ class EditorMessenger extends HTMLElement {
     }
 
     sendMessageFromText(){
-        let text = this.messageField.value;
-        let script = `on doIt\n\t${text}\nend doIt`;
-        this.model.sendMessage({
-            type: 'compile',
-            codeString: script,
-            targetId: this.model.id
-        }, this.model);
-        this.model.sendMessage({
-            type: 'command',
-            commandName: 'doIt',
-            args: [],
-            shouldIgnore: true
-        }, this.model);
+        let text = this.messageField.value + '\n';
+        let parsed = window.System.grammar.match(text, 'StatementList');
+        if(parsed.succeeded()){
+            this.model._semantics(parsed).interpret();
+        }
     }
 };
 

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -359,7 +359,9 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             // We ignore these.
             if(message && typeof(message) !== 'string'){
                 let commandResult = partContext.sendMessage(message, partContext);
-                systemContext.executionStack.current.setLocal('it', commandResult);
+                if(systemContext.executionStack.current){
+                    systemContext.executionStack.current.setLocal('it', commandResult);
+                }
                 return null;
             } else {
                 return message;


### PR DESCRIPTION
-- What
Issue #100  pointed out a bug where sending any user-compiled message
from the Editor's Messenger pane would throw a colossal error. This
was due to the fact that we were using a ratchet temporary user
handler called 'doIt' and compiling the statements in this temporary
message handler. The effect of that was to erase all previously
existing user handlers, a big no-no.

Now we match on the grammar and interpret directly from the Part's
existing semantics.