### PR TITLE
Fixing Image Part Serialization 2

### DIFF
--- a/js/objects/parts/Image.js
+++ b/js/objects/parts/Image.js
@@ -10,13 +10,10 @@ class Image extends Part {
         super(owner);
 
         // Properties
-        this.partProperties.newDynamicProp(
+        this.partProperties.newBasicProp(
             "src",
-            this.setSource,
-            this.getSource
+            null
         );
-
-        this._src = src;
 
         this.partProperties.newBasicProp(
             "mimeType",
@@ -58,55 +55,12 @@ class Image extends Part {
         this.loadImageFromFile = this.loadImageFromFile.bind(this);
     }
 
-
-    loadImageFromSource(senders, sourceUrl){
-        fetch(sourceUrl)
-            .then(response => {
-                let contentType = response.headers.get('content-type');
-                if(!contentType.startsWith('image')){
-                    throw new Error(`Invalid image mimeType: ${contentType}`);
-                }
-                this.partProperties.setPropertyNamed(
-                    this,
-                    "mimeType",
-                    contentType
-                );
-                if(contentType.startsWith("image/svg")){
-                    return response.text().then(text => {
-                        this.partProperties.setPropertyNamed(
-                            this,
-                            'imageData',
-                            text
-                        );
-                    });
-                } else {
-                    return response.blob().then(blob => {
-                        let reader = new FileReader();
-                        reader.onloadend = () => {
-                            this.partProperties.setPropertyNamed(
-                                this,
-                                'imageData',
-                                reader.result // will be the base64 encoded data
-                            );
-                        };
-                        reader.readAsDataURL(blob);
-                    });
-                }
-            })
-            .then(() => {
-                // Manually set the _src.
-                // This ensures that we don't infinitely
-                // call the load operation
-                this._src = sourceUrl;
-            })
-            .catch(err => {
-                console.error(err);
-                this.partProperties.setPropertyNamed(
-                    this,
-                    'imageData',
-                    null
-                );
-            });
+    loadImageFromSource(senders, url){
+        this.partProperties.setPropertyNamed(
+            this,
+            'src',
+            url
+        );
     }
 
     loadImageFromFile(){
@@ -139,17 +93,6 @@ class Image extends Part {
         });
         document.body.append(filePicker);
         filePicker.click();
-    }
-
-    setSource(owner, property, value){
-        owner._src = value;
-        if(value){
-            owner.loadImageFromSource([this], value);
-        }
-    }
-
-    getSource(owner, property){
-        return owner._src;
     }
 
     get type(){

--- a/js/objects/parts/Image.js
+++ b/js/objects/parts/Image.js
@@ -95,6 +95,60 @@ class Image extends Part {
         filePicker.click();
     }
 
+    /**
+     * Serialize this Part's state as JSON.
+     * By default, we do not serialize specific
+     * PartCollection information (recursively),
+     * and only include basics including the current
+     * state of all properties.
+     * ---
+     * Note: Here we override the default implementation
+     * in order to account for src/imageData property
+     * serialization logic
+     */
+    serialize(){
+        let ownerId = null;
+        if(this._owner){
+            ownerId = this._owner.id;
+        }
+        let result = {
+            type: this.type,
+            id: this.id,
+            properties: {},
+            subparts: this.subparts.map(subpart => {
+                return subpart.id;
+            }),
+            ownerId: ownerId
+        };
+
+        // Grab the current image src url value
+        // and the current imageData value
+        let url = this.partProperties.getPropertyNamed(
+            this,
+            'src'
+        );
+        let urlIsValid = (url && url !== "");
+        let currentData = this.partProperties.getPropertyNamed(
+            this,
+            'imageData'
+        );
+        this.partProperties._properties.forEach(prop => {
+            let name = prop.name;
+            let value = prop.getValue(this);
+            if(name == "imageData"){
+                if(!urlIsValid){
+                    result.properties.imageData = value;
+                    result.properties.src = null;
+                } else {
+                    result.properties.imageData = null;
+                }
+            } else {
+                result.properties[name] = value;
+            }
+        });
+        return result;
+    }
+
     get type(){
         return 'image';
     }

--- a/js/objects/views/ImageView.js
+++ b/js/objects/views/ImageView.js
@@ -219,14 +219,11 @@ class ImageView extends PartView {
             'src'
         );
         let result = window.prompt("Edit URL for image:", currentSrc);
-        if(result && result !== '' && result !== currentSrc){
-            this.sendMessage(
-                {
-                    type: 'command',
-                    commandName: 'loadImageFrom',
-                    args: [ result ]
-                },
-                this.model
+        if(result !== currentSrc){
+            this.model.partProperties.setPropertyNamed(
+                this.model,
+                'src',
+                result
             );
         }
     }

--- a/js/objects/views/ImageView.js
+++ b/js/objects/views/ImageView.js
@@ -78,7 +78,7 @@ class ImageView extends PartView {
             if(imageData && imageData !== ""){
                 this.model.partProperties.setPropertyNamed(
                     this.model,
-                    src,
+                    'src',
                     "",
                     false // do not notify
                 );
@@ -102,7 +102,7 @@ class ImageView extends PartView {
             );
             if(urlIsValid){
                 this.loadImageFromSource(src);
-            } else if(!existingImageData || existingImageData == ""){
+            } else {
                 this.setDefaultImage();
             }
         });
@@ -150,9 +150,8 @@ class ImageView extends PartView {
     }
 
     setDefaultImage(){
-        this.model.partProperties.setPropertyNamed(this.model, "imageData", pictureIcon);
+        this.model.partProperties.setPropertyNamed(this.model, "imageData", pictureIcon, false);
         this.model.partProperties.setPropertyNamed(this.model, "mimeType", "image/svg");
-        this.model.partProperties.setPropertyNamed(this.model, "src", "");
         this.updateImageData(pictureIcon);
     }
 
@@ -220,6 +219,12 @@ class ImageView extends PartView {
         );
         let result = window.prompt("Edit URL for image:", currentSrc);
         if(result && result !== currentSrc){
+            this.model.partProperties.setPropertyNamed(
+                this.model,
+                'src',
+                result
+            );
+        } else if(result == ""){
             this.model.partProperties.setPropertyNamed(
                 this.model,
                 'src',

--- a/js/objects/views/ImageView.js
+++ b/js/objects/views/ImageView.js
@@ -70,18 +70,18 @@ class ImageView extends PartView {
 
     afterModelSet(){
 
-        // If the imageData property changes, we only
-        // want to update the enclosed image if there is not
-        // a valid src url. That is the case in which we
-        // are using image data from a local file or data
-        // that should be purely serialized.
+        // If the imageData property has a valid value,
+        // we want to update the actual image but also
+        // clear any `src` property value (without notifying,
+        // to prevent infinite recursion)
         this.onPropChange('imageData', (imageData) => {
-            let url = this.model.partProperties.getPropertyNamed(
-                this.model,
-                'src'
-            );
-            let urlIsValid = (url && url !== "");
-            if(!urlIsValid){
+            if(imageData && imageData !== ""){
+                this.model.partProperties.setPropertyNamed(
+                    this.model,
+                    src,
+                    "",
+                    false // do not notify
+                );
                 this.updateImageData(imageData);
             }
         });
@@ -219,7 +219,7 @@ class ImageView extends PartView {
             'src'
         );
         let result = window.prompt("Edit URL for image:", currentSrc);
-        if(result !== currentSrc){
+        if(result && result !== currentSrc){
             this.model.partProperties.setPropertyNamed(
                 this.model,
                 'src',
@@ -281,14 +281,6 @@ class ImageView extends PartView {
                         // Set the content of the appropriate area
                         // to be SVG inline markup
                         this.updateSvgImage(text);
-
-                        // Set the imageData property for
-                        // potential serialization purposes
-                        this.model.partProperties.setPropertyNamed(
-                            this.model,
-                            'imageData',
-                            text
-                        );
                     });
                 } else {
                     return response.blob().then(blob => {
@@ -296,13 +288,6 @@ class ImageView extends PartView {
                         reader.onloadend = () => {
                             // Set the binary image data
                             this.updateBinaryImage(reader.result);
-                            // Set the imageData property for potential
-                            // serialization purposes
-                            this.model.partProperties.setPropertyNamed(
-                                this.model,
-                                'imageData',
-                                reader.result
-                            );
                         };
                         reader.readAsDataURL(blob);
                     });
@@ -313,7 +298,7 @@ class ImageView extends PartView {
                 this.model.partProperties.setPropertyNamed(
                     this.model,
                     'src',
-                    null
+                    ""
                 );
                 this.model.partProperties.setPropertyNamed(
                     this.model,


### PR DESCRIPTION
## What ##
Until now, we were always serializing both the `src` and `imageData` props for all images. The `imageData` property can contain binary image data that has been loaded. If there is both a `src` (a URL) and the binary data in the serialization, it's redundant and takes up an enormous amount of space.

## Implementation ##
### Refactoring Model -> View flow ###
Prior to this PR, the ImageView was listening for changes to the `imageData` in all cases and updating accordingly. It took no account of the `src` property, mainly because the model was handling the call to `fetch`.
  
We have now reversed this a bit. The model no longer calls `fetch` at all. Each ImageView does this instead, and knows how to render the correct image type (binary or SVG) and then update the `imageData` or `src` properties accordingly. 
  
Calls to the Image command handler `loadImageFromSource` no longer result in a direct fetch execution, but instead simply change the `src` property, upon which the corresponding view(s) will call the fetch and update.
  
### Overriding `serialize()` ###
I have overridden the `serialize()` method in the Image part to take into account the presence of a `src` property (a URL location) when deciding whether or not to serialize the `imageData` property, which can and often does contains potentially megabytes of binary image data.
  
The flow is simple enough: if there is a valid `src` property set (it is not null, undefined, or an empty string), then we _do not_ serialize `imageData`. Otherwise, we attempt to serialize `imageData` no matter its value, even if it's null or empty.
  
## Testing ##
I tested this manually, using different saved snapshots of the Strange Loop presentation stack, which contains many megabytes of images. Here are the results:
| Snapshot | Size |
|--------------|--------|
| Old SL Stack (everything serialized) | **33MB**|
| New SL Stack (anything with `src` ignored) | **1.5MB**|
| Combo SL Stack (first three images have their URLs erased but imageData preserved) | **4.0MB** | 