### PR TITLE
bug in stack.goToCardById stack reference

### DIFF
--- a/js/objects/parts/Stack.js
+++ b/js/objects/parts/Stack.js
@@ -93,8 +93,8 @@ class Stack extends Part {
         if(nextCard._owner != this){
             this._owner.goToStackById(nextCard._owner.id);
         }
-        this.partProperties.setPropertyNamed(
-            this,
+        nextCard._owner.partProperties.setPropertyNamed(
+            nextCard._owner,
             'current',
             nextCard.id
         );


### PR DESCRIPTION
### Main Points ### 

The current implementation didn't account for the card being on a different stack, and would set the target card as "current" on the context stack. This in turn would trigger the default current property on the target card's stack as card 1. Effectively any command like `go to card 2 on stack 2` would actually `go to card 1 of stack 2`

Somewhat related we treat all object specifiers which end in an [index](https://github.com/dkrasner/Simpletalk/blob/master/js/ohm/simpletalk.ohm#L211) or have a [numerical keyword](https://github.com/dkrasner/Simpletalk/blob/master/js/ohm/simpletalk.ohm#L212) as partial, as opposed to terminal. This means that any specifier ending in `... stack N` or `...Nth stack` is non-terminal, whereas in fact it is since we don't allow things like `...stack N of world M`. This is not a technical problem but might cause some difficulties in debugging or understanding our grammar. 

Closes issue #104 