### PR TITLE
fixing nav open property bug in world

### DIFF
--- a/js/objects/views/WorldView.js
+++ b/js/objects/views/WorldView.js
@@ -54,10 +54,6 @@ class WorldView extends PartView {
 
     afterConnected(){
         document.addEventListener('keydown', this.handleKeyDown);
-        let navOpen = this.model.partProperties.getPropertyNamed(this.model, 'navigator-open');
-        if(navOpen){
-            this.toggleNavigator(true);
-        }
     }
 
     afterDisconnected(){
@@ -68,6 +64,10 @@ class WorldView extends PartView {
         // Do an initial update to display
         // the model's current stack
         this.updateCurrentStack();
+        let navOpen = this.model.partProperties.getPropertyNamed(this.model, 'navigator-open');
+        if(navOpen){
+            this.toggleNavigator(true);
+        }
     }
 
     updateCurrentStack(){


### PR DESCRIPTION
### Main Points ###


Previously nav was not dependent on properties and hence on the model. There was a check in the World.afterConnect() which threw an error if the model had not been set yet. One of our serialization tests was throwing this error. I moved it to .afterModelSet()