### PR TITLE
removing halo opening on all new views after deserialization

### DIFF
--- a/js/objects/utils/clipboard.js
+++ b/js/objects/utils/clipboard.js
@@ -57,9 +57,6 @@ class STClipboard {
                             10
                         );
                     }
-                    
-                    // Open Halo on the new view
-                    deserializer.rootViews[0].openHalo();
 
                     // Dispatch the CustomEvent that notifies listeners
                     // that a new view was added (used by Nav etc)
@@ -85,7 +82,7 @@ class STClipboard {
                         lensView.appendChild(newLensView);
                         this._createLensedChildren(newLensView, newPart.subparts);
                     });
-                    
+
                     return;
                 })
                 .catch(err => {


### PR DESCRIPTION
### Main Points ###
The clipboard would call `deserializer.rootViews[0].openHalo();` after deserialization. This is not compatible with our halo-open prop and can force the halo to open on views like cards, stacks, world which do not support it, which breaks the system.

If you want to see it break. Simply add a part to the current card, like area, then tell the current card to copy and the current stack to paste. 

