### PR TITLE
adding missing skip of editor-open prop on image/world serialization

### DIFF
--- a/js/objects/parts/Image.js
+++ b/js/objects/parts/Image.js
@@ -140,6 +140,11 @@ class Image extends Part {
             return prop.getValue(this) !== prop.default;
         }).forEach(prop => {
             let name = prop.name;
+            // due to race-conditions incurred if the editor is
+            // open before world we exclude `editor-open` from serialization
+            if(name == "editor-open"){
+                return;
+            }
             let value = prop.getValue(this);
             if(name == "imageData"){
                 if(!urlIsValid){

--- a/js/objects/parts/WorldStack.js
+++ b/js/objects/parts/WorldStack.js
@@ -246,6 +246,11 @@ class WorldStack extends Part {
             return prop.getValue(this) !== prop.default;
         }).forEach(prop => {
             let name = prop.name;
+            // due to race-conditions incurred if the editor is
+            // open before world we exclude `editor-open` from serialization
+            if(name == "editor-open"){
+                return;
+            }
             let value = prop.getValue(this);
             result.properties[name] = value;
         });


### PR DESCRIPTION
### Main Points ###
 Due to race conditions (editor tries to center the corresponding part which might not have come into view on deserialization), we don't preserve editor prop state.  I had added this to Part.serialize() but forgot to do so for Image and WorldStack. 

This was a bit of a pain to debug b/c deserializing the halo was open not the editor: the `editor-open` prop on Image was causing `halo-open` to be set to true, but the editor itself was not open. Potentially we want to decouple halo and editor but visually it does make sense to have the former open when the latter is... 