### PR TITLE
Overriding browser newlines

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -955,11 +955,11 @@ System._commandHandlers['openScriptEditor'] = function(senders, targetId){
         return;
     }
 
-    let currentCard = this.getCurrentCardModel();
-    let window = this.newModel('window', currentCard.id);
-    let area = this.newModel('area', window.id);
-    let scriptField = this.newModel('field', area.id);
-    let saveButton = this.newModel('button', area.id);
+    const currentCard = this.getCurrentCardModel();
+    const window = this.newModel('window', currentCard.id);
+    const area = this.newModel('area', window.id);
+    const scriptField = this.newModel('field', area.id);
+    const saveButton = this.newModel('button', area.id);
 
 
     // setup the window and stack properties
@@ -976,7 +976,7 @@ System._commandHandlers['openScriptEditor'] = function(senders, targetId){
     area.partProperties.setPropertyNamed(area, "height", "fill");
 
     // script field
-    let targetScript = target.partProperties.getPropertyNamed(target, "script"); 
+    const targetScript = target.partProperties.getPropertyNamed(target, "script");
     scriptField.partProperties.setPropertyNamed(scriptField, "text", targetScript);
     scriptField.partProperties.setPropertyNamed(scriptField, "height", "fill");
     scriptField.partProperties.setPropertyNamed(scriptField, "width", "fill");
@@ -996,7 +996,7 @@ System._commandHandlers['openScriptEditor'] = function(senders, targetId){
     saveButton.partProperties.setPropertyNamed(saveButton, "target", `part id ${target.id}`);
 
     saveButton.partProperties.setPropertyNamed(saveButton, "target", `part id ${target.id}`);
-    let saveScript = `on click\n\ttell target to set "script" to the "text" of first field\nend click`; 
+    const saveScript = `on click\n\ttell target to set "script" to the "text" of first field\nend click`;
     saveButton.partProperties.setPropertyNamed(saveButton, "script", saveScript);
 };
 

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -380,14 +380,17 @@ class FieldView extends PartView {
 
     onKeydown(event){
         // prevent the default tab key to leave focus on the field
-        if(event.key==="Tab"){
+        if(event.key==="Tab" || event.key === "Enter"){
+            let tabNodeValue = '\t';
+            if (event.key === "Enter") {
+                tabNodeValue = '\n';
+            }
             event.preventDefault();
             //document.execCommand('insertHTML', false, '&#x9');
-            let sel = document.getSelection();
-            let range = sel.getRangeAt(0);
+            const sel = document.getSelection();
+            const range = sel.getRangeAt(0);
 
-            let tabNodeValue = '\t';
-            let tabNode = document.createTextNode(tabNodeValue);
+            const tabNode = document.createTextNode(tabNodeValue);
 
             range.insertNode(tabNode);
 


### PR DESCRIPTION
### Main Points ###

Due to inconsistencies of how browsers handle contenteditable divs you could easily run into a situation where the visual text (ie innerHTML) and the actual text (ie innerText) were not the same. This caused havoc especially when trying to edit a script which was not compiling. 

Here is a fun example:
![conteeditablefun](https://user-images.githubusercontent.com/1154326/207066880-064038d8-50f7-436c-a229-6c071a69b055.png)

Note: in the screenshot above "This is NOT A LINE" is actually not a line as far as .innerText is concerned, which you can see by printing it in console, but visually (due to how html markup was generated when you pressed <enter>) it looks like one. So really fun....

**Solution** 

I decided to simply prevent the default and force a "\n" character for every "Enter" keydown. This seems to work fine and doesn't interfere with our script highlighting.