### PR TITLE
allowing property name to be a string literal or variable in set

### DIFF
--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -279,10 +279,10 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             return msg;
         },
 
-        Command_setProperty: function(setLiteral, propNameAsLiteral, toLiteral, literalOrVarName, optionalInClause){
+        Command_setProperty: function(setLiteral, propNameAsLiteralOrVar, toLiteral, literalOrVarName, optionalInClause){
             let specifiedObjectId = optionalInClause.interpret()[0] || null;
             let args = [
-                propNameAsLiteral.interpret(), // The property name
+                propNameAsLiteralOrVar.interpret(), // The property name
                 literalOrVarName.interpret(), // The value or a var representing the value
                 specifiedObjectId
             ];

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -231,7 +231,7 @@ SimpleTalk {
       | "answer" (Conditional | Expression) --answer
       | "delete" ObjectSpecifier --deleteModel
       | "delete" "property" stringLiteral "from"? ObjectSpecifier? --deleteProperty
-      | "set" propertyName "to" Expression InClause? --setProperty
+      | "set" (propertyName | variableName) "to" Expression InClause? --setProperty
       | "set" "selection" propertyName "to" Expression InClause? --setSelection
       | "add" "property" stringLiteral "to"? ObjectSpecifier? --addProperty
       | "add" systemObject stringLiteral? "to" ObjectSpecifier --addModelTo

--- a/js/ohm/tests/test-core-commands.js
+++ b/js/ohm/tests/test-core-commands.js
@@ -168,6 +168,14 @@ describe("Core commands", () => {
             semanticMatchTest(s, "Command_setProperty");
             semanticMatchTest(s, "Statement");
         });
+        it("Set variable prop name to some value this", () => {
+            objects.forEach((d) => {
+                const s = `set aVar to "some value" in this ${d}`;
+                semanticMatchTest(s, "Command");
+                semanticMatchTest(s, "Command_setProperty");
+                semanticMatchTest(s, "Statement");
+            });
+        });
         it("Set target (objectSpecifier, in context)", () => {
             objects.forEach((d) => {
                 const s = `set "target" to first ${d} of current card`;


### PR DESCRIPTION
### Main Points ###

It is nice to be able to parametrize prop names, and pass these along in scripts. For example, 


```
on dothis propName, propVal
     set propName to propVal in [objectSpec]
end dothis


tell first button to dothis "text-color" "red"
```
