### PR TITLE
lens msg bug

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -594,6 +594,7 @@ const System = {
             newLensView.removeAttribute('part-id');
             newLensView.setAttribute('lens-part-id', modelId);
             newLensView.setAttribute('role', 'lens');
+            newLensView.isLensed = true;
             lensView.appendChild(newLensView);
         });
 

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -317,7 +317,7 @@ class PartView extends HTMLElement {
     }
 
     sendMessage(aMessage, target){
-        if(!this.isLensed){
+        if (!(this.isLensed || this.getAttribute("role") == "lens")){
             // Lensed views should not send messages
             window.System.sendMessage(aMessage, this, target);
         }

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -317,7 +317,7 @@ class PartView extends HTMLElement {
     }
 
     sendMessage(aMessage, target){
-        if (!(this.isLensed || this.getAttribute("role") == "lens")){
+        if(!this.isLensed){
             // Lensed views should not send messages
             window.System.sendMessage(aMessage, this, target);
         }


### PR DESCRIPTION
### Main Points ###

Lensed views are views that live in the navigator. 
![image](https://user-images.githubusercontent.com/1154326/218705484-412eb53c-facd-4a0b-894c-b7167a359764.png)


They have the same behavior as "regular" and subscribe to the same model (so for example when you update something in the env you can see it updated in the nav). Essentially they are copies of PartView's in the env, but they are just views and don't do anything else; for example, they should not be sending messages for which there is a check [here](https://github.com/dkrasner/Simpletalk/blob/master/js/objects/views/PartView.js#L320). 

However, we were forgetting to set the PartView JS `isLensed` attribute on the JS PartView object instance, which was causing these to send messages as if they were 'regular' views. In effect, this would cause view change messages (such as `propertyChanged`) to be sent 3x (one for the view in the env, one for the lens stack view - row 1 in nav - and one for the lens card view - row 2 in nav). 