### PR TITLE
refactor: handful of linter appeasing code changes

### DIFF
--- a/js/ohm/tests/test-add-command-grammar.js
+++ b/js/ohm/tests/test-add-command-grammar.js
@@ -1,10 +1,10 @@
 /**
  * Tests for the add and add/to command(s)
  */
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -29,7 +29,7 @@ const objects = [
 ];
 
 describe("Add Model", () => {
-    it ("Basic Add (no id)", () => {
+    it("Basic Add (no id)", () => {
         objects.forEach((d) => {
             const s = `add ${d} to current card`;
             semanticMatchTest(s, "Command");
@@ -37,7 +37,7 @@ describe("Add Model", () => {
             semanticMatchTest(s, "Statement");
         });
     });
-    it ("Basic Add (wth id)", () => {
+    it("Basic Add (wth id)", () => {
         objects.forEach((d) => {
             const s = `add ${d} to card 20`;
             semanticMatchTest(s, "Command");
@@ -45,7 +45,7 @@ describe("Add Model", () => {
             semanticMatchTest(s, "Statement");
         });
     });
-    it ("Add to 'this'", () => {
+    it("Add to 'this'", () => {
         objects.forEach((d) => {
             const s = `add ${d} to this stack`;
             semanticMatchTest(s, "Command");
@@ -53,7 +53,7 @@ describe("Add Model", () => {
             semanticMatchTest(s, "Statement");
         });
     });
-    it ("Add to 'current'", () => {
+    it("Add to 'current'", () => {
         objects.forEach((d) => {
             const s = `add ${d} to current stack`;
             semanticMatchTest(s, "Command");
@@ -61,7 +61,7 @@ describe("Add Model", () => {
             semanticMatchTest(s, "Statement");
         });
     });
-    it ("Basic Add (with name, no id)", () => {
+    it("Basic Add (with name, no id)", () => {
         objects.forEach((d) => {
             const s = `add ${d} "newPart 123" to current card`;
             semanticMatchTest(s, "Command");
@@ -69,7 +69,7 @@ describe("Add Model", () => {
             semanticMatchTest(s, "Statement");
         });
     });
-    it ("Basic Add (with name, wth id)", () => {
+    it("Basic Add (with name, wth id)", () => {
         objects.forEach((d) => {
             const s = `add ${d} "newPart 123" to card 20`;
             semanticMatchTest(s, "Command");
@@ -77,7 +77,7 @@ describe("Add Model", () => {
             semanticMatchTest(s, "Statement");
         });
     });
-    it ("Add named to 'this'", () => {
+    it("Add named to 'this'", () => {
         objects.forEach((d) => {
             const s = `add ${d} "newPart 123" to this stack`;
             semanticMatchTest(s, "Command");
@@ -85,7 +85,7 @@ describe("Add Model", () => {
             semanticMatchTest(s, "Statement");
         });
     });
-    it ("Add named to 'current'", () => {
+    it("Add named to 'current'", () => {
         objects.forEach((d) => {
             const s = `add ${d} "newPart123" to current stack`;
             semanticMatchTest(s, "Command");
@@ -110,13 +110,13 @@ describe("Add Model", () => {
             semanticMatchTest(s, "Statement");
         });
     });
-    it ("Bad add (world)", () => {
+    it("Bad add (world)", () => {
         const s = "add world to card";
         semanticMatchFailTest(s, "Command_addModel");
         semanticMatchFailTest(s, "Command_addModelTo");
         semanticMatchFailTest(s, "Command");
     });
-    it ("Bad add (invalid context)", () => {
+    it("Bad add (invalid context)", () => {
         const s = "add button to new stack";
         semanticMatchFailTest(s, "Command_addModel");
         semanticMatchFailTest(s, "Command_addModelTo");

--- a/js/ohm/tests/test-arbitrary-command-grammar.js
+++ b/js/ohm/tests/test-arbitrary-command-grammar.js
@@ -2,10 +2,10 @@
  * Tests dealing with user-defined commands
  * and messages
  */
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -13,23 +13,23 @@ var assert = chai.assert;
 const matchTest = (str) => {
     const match = g.match(str);
     assert.isTrue(match.succeeded());
-}
+};
 const semanticMatchTest = (str, semanticType) => {
     const typeMatch = g.match(str, semanticType);
     assert.isTrue(typeMatch.succeeded());
-}
+};
 const matchAndsemanticMatchTest = (str, semanticType) => {
     matchTest(str);
     const typeMatch = g.match(str, semanticType);
     assert.isTrue(typeMatch.succeeded());
-}
+};
 const semanticMatchFailTest = (str, semanticType) => {
     const typeMatch = g.match(str, semanticType);
     assert.isFalse(typeMatch.succeeded());
-}
-String.prototype.unCapitalize = function() {
+};
+String.prototype.unCapitalize = function () {
     return this.charAt(0).toLowerCase() + this.slice(1);
-}
+};
 
 
 describe('Basic Definitions', () => {
@@ -131,7 +131,7 @@ describe("Arbitrary Message Statements with literal arguments", () => {
             semanticMatchTest(str, "Command_arbitraryCommand");
         });
         it('with one argument, negative', () => {
-            str = `myCustomCommand -0.034`;
+            const str = `myCustomCommand -0.034`;
             semanticMatchTest(str, "Command");
             semanticMatchTest(str, "Command_arbitraryCommand");
         });

--- a/js/ohm/tests/test-comment-grammar.js
+++ b/js/ohm/tests/test-comment-grammar.js
@@ -2,10 +2,10 @@
  * Test Comments in the grammar
  */
 
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -13,23 +13,23 @@ var assert = chai.assert;
 const matchTest = (str) => {
     const match = g.match(str);
     assert.isTrue(match.succeeded());
-}
+};
 const semanticMatchTest = (str, semanticType) => {
     const typeMatch = g.match(str, semanticType);
     assert.isTrue(typeMatch.succeeded());
-}
+};
 const matchAndsemanticMatchTest = (str, semanticType) => {
     matchTest(str);
     const typeMatch = g.match(str, semanticType);
     assert.isTrue(typeMatch.succeeded());
-}
+};
 const semanticMatchFailTest = (str, semanticType) => {
     const typeMatch = g.match(str, semanticType);
     assert.isFalse(typeMatch.succeeded());
-}
-String.prototype.unCapitalize = function() {
+};
+String.prototype.unCapitalize = function () {
     return this.charAt(0).toLowerCase() + this.slice(1);
-}
+};
 
 describe("Comment Grammar Tests", () => {
     describe("Basic", () => {
@@ -81,7 +81,7 @@ describe("Comment Grammar Tests", () => {
                 'answer "hello"',
                 'end doSomething'
             ].join('\n');
-            matchTest(str, 'Script');
+            matchTest(str);
         });
 
         it("Can handle comments at the inside top of a handler", () => {

--- a/js/ohm/tests/test-core-commands.js
+++ b/js/ohm/tests/test-core-commands.js
@@ -1,7 +1,7 @@
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -23,7 +23,7 @@ const semanticMatchFailTest = (str, semanticType) => {
     const typeMatch = g.match(str, semanticType);
     assert.isFalse(typeMatch.succeeded());
 };
-String.prototype.unCapitalize = function() {
+String.prototype.unCapitalize = function () {
     return this.charAt(0).toLowerCase() + this.slice(1);
 };
 
@@ -34,14 +34,14 @@ const objects = [
 
 describe("Core commands", () => {
     describe("Go To", () => {
-        it ("go to direction with no object fails", () => {
+        it("go to direction with no object fails", () => {
             const direction = ["next", "previous"];
             direction.forEach((d) => {
                 const s = `go to ${d}`;
                 semanticMatchFailTest(s, "Command");
             });
         });
-        it ("go to with object", () => {
+        it("go to with object", () => {
             const direction = ["next", "previous"];
             direction.forEach((d) => {
                 const s = `go to ${d} card`;
@@ -50,41 +50,41 @@ describe("Core commands", () => {
                 semanticMatchTest(s, "Statement");
             });
         });
-        it ("go to by index", () => {
+        it("go to by index", () => {
             const s = "go to card 2";
             semanticMatchTest(s, "Command");
             semanticMatchTest(s, "Command_goToByObjectSpecifier");
             semanticMatchTest(s, "Statement");
         });
-        it ("go to by id", () => {
+        it("go to by id", () => {
             const s = "go to stack id 2";
             semanticMatchTest(s, "Command");
             semanticMatchTest(s, "Command_goToByObjectSpecifier");
             semanticMatchTest(s, "Statement");
         });
-        it ("go to by name", () => {
+        it("go to by name", () => {
             const s = 'go to stack "cool stack"';
             semanticMatchTest(s, "Command");
             semanticMatchTest(s, "Command_goToByObjectSpecifier");
             semanticMatchTest(s, "Statement");
         });
-        it ("go to website", () => {
+        it("go to website", () => {
             const s = 'go to website "http//coolsite.awesome"';
             semanticMatchTest(s, "Command");
             semanticMatchTest(s, "Command_goToWebsite");
             semanticMatchTest(s, "Statement");
         });
-        it ("Bad go to: invalid object", () => {
+        it("Bad go to: invalid object", () => {
             const s = "go to card";
             semanticMatchFailTest(s, "Command");
         });
-        it ("Bad go to: invalid structure", () => {
+        it("Bad go to: invalid structure", () => {
             const s = "go to next card 42";
             semanticMatchFailTest(s, "Command");
         });
     });
     describe("Delete", () => {
-        it ("Basic Remove Model (no id)", () => {
+        it("Basic Remove Model (no id)", () => {
             const direction = ["stack", "background", "card", "button"];
             direction.forEach((d) => {
                 const s = `delete this ${d}`;
@@ -93,7 +93,7 @@ describe("Core commands", () => {
                 semanticMatchTest(s, "Statement");
             });
         });
-        it ("Basic Remove model (with id)", () => {
+        it("Basic Remove model (with id)", () => {
             const direction = ["stack", "background", "card", "button"];
             direction.forEach((d) => {
                 const s = `delete ${d} 20`;
@@ -102,38 +102,38 @@ describe("Core commands", () => {
                 semanticMatchTest(s, "Statement");
             });
         });
-        it ("Remove property with object specifier", () => {
+        it("Remove property with object specifier", () => {
             const s = `delete property "MyProp" from this button`;
             semanticMatchTest(s, "Command");
             semanticMatchTest(s, "Command_deleteProperty");
             semanticMatchTest(s, "Statement");
         });
-        it ("Remove property without object specifier", () => {
+        it("Remove property without object specifier", () => {
             const s = `delete property "MyProp"`;
             semanticMatchTest(s, "Command");
             semanticMatchTest(s, "Command_deleteProperty");
             semanticMatchTest(s, "Statement");
         });
-        it.skip ("Bad delete (world)", () => {
+        it.skip("Bad delete (world)", () => {
             const s = "delete this world";
             semanticMatchFailTest(s, "Command_deleteModel");
             semanticMatchFailTest(s, "Command");
         });
     });
     describe("Answer", () => {
-        it ("simple answer", () => {
+        it("simple answer", () => {
             const s = "answer \"42\"";
             semanticMatchTest(s, "Command");
             semanticMatchTest(s, "Command_answer");
             semanticMatchTest(s, "Statement");
         });
-        it ("bad answer", () => {
+        it("bad answer", () => {
             const s = "answer \"42\" \"42\"";
             semanticMatchFailTest(s, "Command");
         });
     });
     describe("Set", () => {
-        it ("Set someProperty with id", () => {
+        it("Set someProperty with id", () => {
 
             objects.forEach((d) => {
                 const s = `set "someProperty" to "some value" in ${d} id 10`;
@@ -142,7 +142,7 @@ describe("Core commands", () => {
                 semanticMatchTest(s, "Statement");
             });
         });
-        it ("Set someProperty (in context)", () => {
+        it("Set someProperty (in context)", () => {
             objects.forEach((d) => {
                 const s = `set "someProperty" to "some value"`;
                 semanticMatchTest(s, "Command");
@@ -194,13 +194,13 @@ describe("Core commands", () => {
         });
     });
     describe("Arbitrary", () => {
-        it ("arbitrary command", () => {
+        it("arbitrary command", () => {
             const s = "anythinggoes";
             semanticMatchTest(s, "Command");
             semanticMatchTest(s, "Statement");
         });
     });
-    it ("Bad command (arbitrary with digits)", () => {
+    it("Bad command (arbitrary with digits)", () => {
         semanticMatchFailTest("1234arrowKe", "Command");
     });
 });

--- a/js/ohm/tests/test-factor-expression-grammar.js
+++ b/js/ohm/tests/test-factor-expression-grammar.js
@@ -3,10 +3,10 @@
  * grammar parsing.
  */
 
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -14,23 +14,23 @@ var assert = chai.assert;
 const matchTest = (str) => {
     const match = g.match(str);
     assert.isTrue(match.succeeded());
-}
+};
 const semanticMatchTest = (str, semanticType) => {
     const typeMatch = g.match(str, semanticType);
     assert.isTrue(typeMatch.succeeded());
-}
+};
 const matchAndsemanticMatchTest = (str, semanticType) => {
     matchTest(str);
     const typeMatch = g.match(str, semanticType);
     assert.isTrue(typeMatch.succeeded());
-}
+};
 const semanticMatchFailTest = (str, semanticType) => {
     const typeMatch = g.match(str, semanticType);
     assert.isFalse(typeMatch.succeeded());
-}
-String.prototype.unCapitalize = function() {
+};
+String.prototype.unCapitalize = function () {
     return this.charAt(0).toLowerCase() + this.slice(1);
-}
+};
 
 
 describe('Arithmetic', () => {

--- a/js/ohm/tests/test-grammar.js
+++ b/js/ohm/tests/test-grammar.js
@@ -1,7 +1,7 @@
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -23,7 +23,7 @@ const semanticMatchFailTest = (str, semanticType) => {
     const typeMatch = g.match(str, semanticType);
     assert.isFalse(typeMatch.succeeded());
 };
-String.prototype.unCapitalize = function() {
+String.prototype.unCapitalize = function () {
     return this.charAt(0).toLowerCase() + this.slice(1);
 };
 
@@ -48,7 +48,7 @@ describe("SimpleTalk Grammar", () => {
             const s = "-- mycomment part2";
             matchAndsemanticMatchTest(s, 'comment');
         });
-        it("positive integer", () =>{
+        it("positive integer", () => {
             const s = "24";
             semanticMatchTest(s, 'integerLiteral');
         });
@@ -107,7 +107,7 @@ describe("SimpleTalk Grammar", () => {
 
     // TODO add more tests for handlers, comments, end etc
     describe("Messages", () => {
-        it ("Message name", () => {
+        it("Message name", () => {
             const strings = [
                 "f", "F", "amessage", "aMessage", "aMessage"
             ];
@@ -115,7 +115,7 @@ describe("SimpleTalk Grammar", () => {
                 semanticMatchTest(s, 'messageName');
             });
         });
-        it ("Bad message name", () => {
+        it("Bad message name", () => {
             const strings = [
                 "1", "1m", "1M", "m1", "M1", " message", "then", "on", "end"
             ];
@@ -123,15 +123,15 @@ describe("SimpleTalk Grammar", () => {
                 semanticMatchFailTest(s, 'messageName');
             });
         });
-        it ("Can parse message names beginning with 'do'", () => {
+        it("Can parse message names beginning with 'do'", () => {
             let str = "doSomething";
             semanticMatchTest(str, 'messageName');
         });
-        it ("Message handler (no args, no statements)", () => {
+        it("Message handler (no args, no statements)", () => {
             const s = `on myMessage\nend myMessage`;
             matchAndsemanticMatchTest(s, 'MessageHandler');
         });
-        it ("Message handler (args, no statements)", () => {
+        it("Message handler (args, no statements)", () => {
             const s = `on myNewMessage arg1, arg2\nend myNewMessage`;
             matchAndsemanticMatchTest(s, 'MessageHandler');
         });
@@ -144,7 +144,7 @@ describe("SimpleTalk Grammar", () => {
             let match = g.match(invalidStr);
             assert.isFalse(match.succeeded());
         });
-        it ("Built in message syntax", () => {
+        it("Built in message syntax", () => {
             const strings = [
                 "close", "closeStack", "commandKeyDown", "quit"
             ];
@@ -182,43 +182,57 @@ describe("SimpleTalk Grammar", () => {
         });
         describe("Built in system messages", () => {
             const tests = [
-                {strings: [
-                    "closeBackground", "closeButton", "closeCard", "closeField", "closeStack"
-                ],
-                name: "Close Object"},
-                {strings: [
-                    "openBackground", "openButton", "openCard", "openField", "openStack"
-                ],
-                name: "Open Object"},
-                {strings: [
-                    "deleteBackground", "deleteButton", "deleteCard", "deleteField", "deleteStack"
-                ],
-                name: "Delete Object"},
-                {strings: [
-                    "newBackground", "newButton", "newCard", "newField", "newStack"
-                ],
-                name: "New Object"},
-                {strings: [
-                    "mouseDoubleClick", "mouseDown", "mouseDownInPicture", "mouseEnter",
-                    "mouseLeave", "mouseStillDown", "mouseUpInPicture", "mouseUp", "mouseWithin"
-                ],
-                name: "Mouse Event"},
-                {strings: [
-                    "arrowKey", "commandKeyDown", "controlKey", "enterKey",
-                    "functionKey", "keyDown", "returnKey", "tabKey"
-                ],
-                skipSpecific: true,
-                name: "Key Event"},
-                {strings: [
-                    "systemEvent", "doMenu", "enterInField" , "exitField", "help",
-                    "hide menubar", "idle", "moveWindow", "quit", "resumeStack",
-                    "resume", "returnInField", "show menubar", "sizeWindow", "startUp",
-                    "suspendStack", "suspend"
-                ],
-                skipSpecific: true,
-                name: "Other System Messages"},
+                {
+                    strings: [
+                        "closeBackground", "closeButton", "closeCard", "closeField", "closeStack"
+                    ],
+                    name: "Close Object"
+                },
+                {
+                    strings: [
+                        "openBackground", "openButton", "openCard", "openField", "openStack"
+                    ],
+                    name: "Open Object"
+                },
+                {
+                    strings: [
+                        "deleteBackground", "deleteButton", "deleteCard", "deleteField", "deleteStack"
+                    ],
+                    name: "Delete Object"
+                },
+                {
+                    strings: [
+                        "newBackground", "newButton", "newCard", "newField", "newStack"
+                    ],
+                    name: "New Object"
+                },
+                {
+                    strings: [
+                        "mouseDoubleClick", "mouseDown", "mouseDownInPicture", "mouseEnter",
+                        "mouseLeave", "mouseStillDown", "mouseUpInPicture", "mouseUp", "mouseWithin"
+                    ],
+                    name: "Mouse Event"
+                },
+                {
+                    strings: [
+                        "arrowKey", "commandKeyDown", "controlKey", "enterKey",
+                        "functionKey", "keyDown", "returnKey", "tabKey"
+                    ],
+                    skipSpecific: true,
+                    name: "Key Event"
+                },
+                {
+                    strings: [
+                        "systemEvent", "doMenu", "enterInField", "exitField", "help",
+                        "hide menubar", "idle", "moveWindow", "quit", "resumeStack",
+                        "resume", "returnInField", "show menubar", "sizeWindow", "startUp",
+                        "suspendStack", "suspend"
+                    ],
+                    skipSpecific: true,
+                    name: "Other System Messages"
+                },
             ];
-            tests.forEach( (test) => {
+            tests.forEach((test) => {
                 it(`${test.name}`, () => {
                     const cl = test.name.replace(" ", "").unCapitalize();
                     test.strings.forEach((s) => {
@@ -265,42 +279,42 @@ describe("SimpleTalk Grammar", () => {
     describe("punctuation", () => {
         it('Basic', () => {
             const strings = [":", ";", ".", ",", "?", "!", "-"];
-            strings.forEach((s) => {semanticMatchTest(s, 'punctuation')});
+            strings.forEach((s) => { semanticMatchTest(s, 'punctuation'); });
         });
         it('Does not match some examples', () => {
             const s = '"this is a\t\ntest"';
             const strings = ["a", " ", "/"];
-            strings.forEach((s) => {semanticMatchFailTest(s, 'punctuation')});
+            strings.forEach((s) => { semanticMatchFailTest(s, 'punctuation'); });
         });
     });
     describe("object Id", () => {
-        it ("Basic Id", () => {
+        it("Basic Id", () => {
             semanticMatchTest("myNewId", "objectId");
         });
-        it ("Id with constters and digits", () => {
+        it("Id with constters and digits", () => {
             semanticMatchTest("newIdl123", "objectId");
         });
-        it ("Bad objetId (with space)", () => {
+        it("Bad objetId (with space)", () => {
             semanticMatchFailTest(" badId", "objectId");
         });
-        it ("Bad objetId (with space)", () => {
+        it("Bad objetId (with space)", () => {
             semanticMatchFailTest(" badId", "objectId");
         });
     });
     describe("Parameter List", () => {
-        it ("Single param list", () => {
+        it("Single param list", () => {
             semanticMatchTest("param1", "ParameterList");
         });
-        it ("Simple param list", () => {
+        it("Simple param list", () => {
             semanticMatchTest("param1, param2", "ParameterList");
         });
-        it ("Param list with digits", () => {
+        it("Param list with digits", () => {
             semanticMatchTest("12, 22, newparam123", "ParameterList");
         });
-        it ("Bad param list (without spaces)", () => {
+        it("Bad param list (without spaces)", () => {
             semanticMatchFailTest("param1,param2", "ParameterList");
         });
-        it ("Bad param list (space)", () => {
+        it("Bad param list (space)", () => {
             semanticMatchFailTest("pa ram1, param2", "ParameterList");
         });
     });

--- a/js/ohm/tests/test-if-then-else-grammar.js
+++ b/js/ohm/tests/test-if-then-else-grammar.js
@@ -14,10 +14,10 @@
  *      else <command>`
  *
  */
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;

--- a/js/ohm/tests/test-object-specifier-grammar.js
+++ b/js/ohm/tests/test-object-specifier-grammar.js
@@ -1,7 +1,7 @@
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;

--- a/js/ohm/tests/test-property-value-grammar.js
+++ b/js/ohm/tests/test-property-value-grammar.js
@@ -1,7 +1,7 @@
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;

--- a/js/ohm/tests/test-repeat-grammar.js
+++ b/js/ohm/tests/test-repeat-grammar.js
@@ -3,10 +3,10 @@
  * --------------------------------
  * Tests the grammar of looping constructs
  */
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -63,7 +63,7 @@ describe("RepeatControlForm tests", () => {
         });
     });
     describe("whileCondition", () => {
-       it("Can do a boolean literal", () => {
+        it("Can do a boolean literal", () => {
             let str = `repeat while true`;
             semanticMatchTest(str, "RepeatControlForm_whileCondition");
         });
@@ -78,7 +78,7 @@ describe("RepeatControlForm tests", () => {
         it("Can use a conditional that has variable name(s)", () => {
             let str = `repeat while myVariable is 5`;
             semanticMatchTest(str, "RepeatControlForm_whileCondition");
-        }); 
+        });
     });
     describe("withStartFinish", () => {
         it("Can use a basic variable name with literal integer range", () => {
@@ -170,14 +170,14 @@ describe("Repeat full script tests", () => {
 describe("Misc full script repeat tests", () => {
     it("Can parse an exit repeat in nested if block", () => {
         let script = [
-        "on click",
-        "put 0 into Counter",
-        "repeat until Counter == 5",
-        "answer Counter",
-        "put (Counter + 1) into Counter",
-        "if Counter >= 3 then exit repeat",
-        "end repeat",
-        "end click"
+            "on click",
+            "put 0 into Counter",
+            "repeat until Counter == 5",
+            "answer Counter",
+            "put (Counter + 1) into Counter",
+            "if Counter >= 3 then exit repeat",
+            "end repeat",
+            "end click"
         ].join("\n");
         semanticMatchTest(script, "Script");
         semanticMatchTest(script, "MessageHandler");

--- a/js/ohm/tests/test-string-grammar.js
+++ b/js/ohm/tests/test-string-grammar.js
@@ -2,10 +2,10 @@
  * String and stringLiteral
  * related grammatical tests
  **/
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -13,7 +13,7 @@ var assert = chai.assert;
 const matchTest = (str) => {
     const match = g.match(str);
     assert.isTrue(match.succeeded());
-}
+};
 const semanticMatchTest = (str, semanticType) => {
     const typeMatch = g.match(str, semanticType);
     assert.isTrue(typeMatch.succeeded());

--- a/js/ohm/tests/test-tell-grammar.js
+++ b/js/ohm/tests/test-tell-grammar.js
@@ -1,8 +1,8 @@
 /** Test grammar of the new 'tell' command **/
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;

--- a/js/ohm/tests/test-thereisa-grammar.js
+++ b/js/ohm/tests/test-thereisa-grammar.js
@@ -1,10 +1,10 @@
 /**
  * Tests for the 'there is a'command(s)
  */
-ohm = require('ohm-js');
+const ohm = require('ohm-js');
 // Instantiate the grammar.
 var fs = require('fs');
-var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm').toString());
 
 var chai = require('chai');
 var assert = chai.assert;
@@ -28,41 +28,41 @@ const objects = [
     "drawing", "audio", "image"
 ];
 
-describe("'there is a' ObjectSpecifier" , () => {
-    it ("Basic (current card)", () => {
+describe("'there is a' ObjectSpecifier", () => {
+    it("Basic (current card)", () => {
         const s = `there is a current card`;
         semanticMatchTest(s, "Conditional");
         semanticMatchTest(s, "ThereIsAnObjectConditional");
     });
-    it ("Basic (wth id)", () => {
+    it("Basic (wth id)", () => {
         objects.forEach((d) => {
             const s = `there is a ${d} 20`;
             semanticMatchTest(s, "Conditional");
             semanticMatchTest(s, "ThereIsAnObjectConditional");
         });
     });
-    it ("By name of current stack", () => {
+    it("By name of current stack", () => {
         objects.forEach((d) => {
             const s = `there is a ${d} "New" of current stack`;
             semanticMatchTest(s, "Conditional");
             semanticMatchTest(s, "ThereIsAnObjectConditional");
         });
     });
-    it ("Basic (with name, wth id)", () => {
+    it("Basic (with name, wth id)", () => {
         objects.forEach((d) => {
             const s = `there is a ${d} "newPart 123" of card 20`;
             semanticMatchTest(s, "Conditional");
             semanticMatchTest(s, "ThereIsAnObjectConditional");
         });
     });
-    it ("'Of this'", () => {
+    it("'Of this'", () => {
         objects.forEach((d) => {
             const s = `there is a  ${d} "newPart 123" of this stack`;
             semanticMatchTest(s, "Conditional");
             semanticMatchTest(s, "ThereIsAnObjectConditional");
         });
     });
-    it ("Named of 'current'", () => {
+    it("Named of 'current'", () => {
         objects.forEach((d) => {
             const s = `there is a ${d} "newPart123" of current stack`;
             semanticMatchTest(s, "Conditional");
@@ -91,13 +91,13 @@ describe("'there is a' ObjectSpecifier" , () => {
         });
     });
 });
-describe("'there is not a' ObjectSpecifier" , () => {
-    it ("Basic (current card)", () => {
+describe("'there is not a' ObjectSpecifier", () => {
+    it("Basic (current card)", () => {
         const s = `there is not a current card`;
         semanticMatchTest(s, "Conditional");
         semanticMatchTest(s, "ThereIsNotAnObjectConditional");
     });
-    it ("Basic (wth id)", () => {
+    it("Basic (wth id)", () => {
         objects.forEach((d) => {
             const s = `there is not a ${d} 20`;
             semanticMatchTest(s, "Conditional");
@@ -127,28 +127,28 @@ describe("'there is not a' ObjectSpecifier" , () => {
     });
 });
 
-describe("there is a property" , () => {
-    it ("without specifier", () => {
+describe("there is a property", () => {
+    it("without specifier", () => {
         const s = `there is a property "super prop"`;
         semanticMatchTest(s, "Conditional");
         semanticMatchTest(s, "ThereIsAPropertyConditional");
         semanticMatchTest(s, "ThereIsAPropertyConditional_withoutSpecifier");
     });
-    it ("with specifier", () => {
+    it("with specifier", () => {
         const s = `there is a property "super prop" of first button of current card`;
         semanticMatchTest(s, "Conditional");
         semanticMatchTest(s, "ThereIsAPropertyConditional");
         semanticMatchTest(s, "ThereIsAPropertyConditional_withSpecifier");
     });
 });
-describe("there is not a property" , () => {
-    it ("without specifier", () => {
+describe("there is not a property", () => {
+    it("without specifier", () => {
         const s = `there is not a property "super prop"`;
         semanticMatchTest(s, "Conditional");
         semanticMatchTest(s, "ThereIsNotAPropertyConditional");
         semanticMatchTest(s, "ThereIsNotAPropertyConditional_withoutSpecifier");
     });
-    it ("with specifier", () => {
+    it("with specifier", () => {
         const s = `there is not a property "super prop" of first button of current card`;
         semanticMatchTest(s, "Conditional");
         semanticMatchTest(s, "ThereIsNotAPropertyConditional");

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "webpack-cli": "^3.3.12"
   },
   "devDependencies": {
+    "@types/mocha": "^10.0.1",
     "chai": "^4.2.0",
     "esm": "^3.2.25",
     "mocha": "^8.0.1"


### PR DESCRIPTION

Really only intended to add @types/mocha to the dev dependencies and make a handful of linter appeasing changes:
1. add 'const' to ohm where missing
2. explicit .toString() on Buffer when initializing grammar. 

Auto-formatter made the other changes.
