### PR TITLE
chore: add eslint dev dependencies and configs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/js/objects/examples/older/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    mocha: true,
+    commonjs: true
+  },
+  extends: 'eslint:recommended',
+  overrides: [
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  rules: {
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha --require esm ./js/ohm/tests/ && ./js-tests.sh",
     "test-grammar": "./node_modules/mocha/bin/mocha --require esm ./js/ohm/tests/",
-    "build-dev": "webpack --config ./webpack.config.js"
+    "build-dev": "webpack --config ./webpack.config.js",
+    "eslint:check": "eslint --ext .js js"
   },
   "repository": {
     "type": "git",
@@ -40,6 +41,9 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
+    "eslint": "^7.32.0 || ^8.2.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.25.2",
     "esm": "^3.2.25",
     "mocha": "^8.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "./node_modules/mocha/bin/mocha --require esm ./js/ohm/tests/ && ./js-tests.sh",
     "test-grammar": "./node_modules/mocha/bin/mocha --require esm ./js/ohm/tests/",
     "build-dev": "webpack --config ./webpack.config.js",
-    "eslint:check": "eslint --ext .js js"
+    "eslint:check": "eslint --ext .js js",
+    "eslint:fix": "eslint --fix --ext .js js"
+
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add eslint dependencies and initial configs.

check  with "yarn eslint:check" or "npm run eslint:check"

autofix with "yarn eslint:fix" or "npm run eslint:fix"

*airbnb rules too noisy for now. can turn them on incrementally
