### PR TITLE
chore: add serve-dev command to package.json

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,8 @@ module.exports = {
     browser: true,
     es2021: true,
     mocha: true,
-    commonjs: true
+    commonjs: true,
+    node: true,
   },
   extends: 'eslint:recommended',
   overrides: [

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test-grammar": "./node_modules/mocha/bin/mocha --require esm ./js/ohm/tests/",
     "build-dev": "webpack --config ./webpack.config.js",
     "eslint:check": "eslint --ext .js js",
-    "eslint:fix": "eslint --fix --ext .js js"
-
+    "eslint:fix": "eslint --fix --ext .js js",
+    "serve-dev": "webpack --config ./webpack.config.js & nodemon --watch 'objects/build/*' --exec 'http-server --cors -p 8000'"
   },
   "repository": {
     "type": "git",
@@ -38,8 +38,8 @@
     "node-fetch": "^2.6.1",
     "ohm-js": "^15.3.0",
     "uuid": "^3.4.0",
-    "webpack": "^4.44.1",
-    "webpack-cli": "^3.3.12"
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",
@@ -47,6 +47,8 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.25.2",
     "esm": "^3.2.25",
-    "mocha": "^8.0.1"
+    "http-server": "^14.1.1",
+    "mocha": "^8.0.1",
+    "nodemon": "^2.0.21"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,8 +6,9 @@ module.exports = {
     entry: {
         devSystem: './js/objects/System.js',
     },
+    watch: true,
     output: {
         path: path.resolve(__dirname, 'js', 'objects', 'build'),
         filename: '[name].bundle.js'
-    }
+    },
 };


### PR DESCRIPTION
Serve local dev with http-server. Webpack will watch for changes and rebuild. Nodemon will watch for changes and restart the server. 

Use "yarn serve-dev" or "npm run serve-dev".

does NOT hot reload in the browser yet. Will add that shortly. 


