### PR TITLE
fixing up subpart highlighting bug in the editor

### DIFF
--- a/js/objects/views/editors/EditorSubpartsPane.js
+++ b/js/objects/views/editors/EditorSubpartsPane.js
@@ -267,6 +267,10 @@ class EditorSubpartsPane extends HTMLElement {
     }
 
     onSubpartItemClick(event){
+        // make sure that we remove all highliting on views
+        this.getLocationViews(event).forEach((view) => {
+            view.unhighlight();
+        });
         let id = event.currentTarget.getAttribute('ref-id');
         let targetPart = window.System.partsById[id];
         if(targetPart){


### PR DESCRIPTION
Fixes the following bug which leaves the subpart highlighting in place when the part is selected/clicked. 
https://user-images.githubusercontent.com/1154326/236673161-c60a24b6-b9d7-437f-9f32-37d422f7744a.mov

