### PR TITLE
Sizing

### DIFF
--- a/js/objects/parts/Area.js
+++ b/js/objects/parts/Area.js
@@ -46,14 +46,14 @@ class Area extends Part {
         this.partProperties.setPropertyNamed(
             this,
             'width',
-            50,
+            400,
             true, // notify
             true // set default
         );
         this.partProperties.setPropertyNamed(
             this,
             'height',
-            50,
+            200,
             true, // notify
             true // set default
         );

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -34,6 +34,7 @@ class PartView extends HTMLElement {
         this.wantsHaloScriptEdit = true;
         this.wantsHaloEdit = true;
         this.wantsHaloDelete = true;
+        this.wantsHaloSizeDisplay = true;
         this.wantsHalo = true;
         this.hasOpenHalo = false;
 


### PR DESCRIPTION
### Main Points ###

This PR adds part size information to the halo view. The latter now has a [resize observer](https://github.com/dkrasner/Simpletalk/compare/wysiwyg...daniel-area-sizing?expand=1#diff-55a3f928e9f75b381efdcfd73c753ac548d1f4a15eeca5d38639dc79744b23eaR260) which listens to the target element size changes and display it's width and height property like so:

https://user-images.githubusercontent.com/1154326/236676890-79681ea4-ecb9-4eca-b419-11e4cd5ade2a.mov


This display can be turned off for specific parts by setting [wantsHaloSizeDisplay](https://github.com/dkrasner/Simpletalk/compare/wysiwyg...daniel-area-sizing?expand=1#diff-f8a644f39713f7d56b51b944769a8733fceb081884704c2a73b93c232b554560R37) to false. At the moment it is true (default) for all. In the future, we can imagine this halo configuration becoming properties themselves which can be interfaced directly as for all other props. 