### PR TITLE
grid1

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -205,8 +205,6 @@ st-field {
    AreaView.js*/
 :not(st-area).grid-layout {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(3, 1fr);
 }
 
 .grid-layout > *:not(st-window):not(st-editor) {

--- a/css/core.css
+++ b/css/core.css
@@ -199,6 +199,26 @@ st-field {
 
 /* =Layout Class Styles
  * --------------------------------------------------------*/
+
+/* areas have an internal wrapper where subparts DOM elements
+   actually reside; see the template definition and style
+   AreaView.js*/
+:not(st-area).grid-layout {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(3, 1fr);
+}
+
+.grid-layout > *:not(st-window):not(st-editor) {
+    position: relative !important;
+    top: auto !important;
+    left: auto !important;
+}
+
+.grid-layout > * {
+    place-self: center;
+}
+
 .list-layout {
     display: flex;
     flex-direction: row;

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -284,6 +284,19 @@ describe('Styling Properties', () => {
             buttonModel = buttonView.model;
             assert.exists(buttonModel);
         });
+        it('By default parts have no grid layout defined', () => {
+            assert.isFalse(currentCardView.classList.contains("grid-layout"));
+        });
+        it('Setting layout to grid adds corresponding class', () => {
+            currentCardModel.partProperties.setPropertyNamed(currentCardModel, "layout", "grid");
+            assert.isTrue(currentCardView.classList.contains("grid-layout"));
+        });
+        it('Setting grid size', () => {
+            currentCardModel.partProperties.setPropertyNamed(currentCardModel, "grid-size", "3,4");
+            let styleProp = currentCardModel.partProperties.getPropertyNamed(currentCardModel, "cssStyle");
+            assert.equal(styleProp['grid-template-columns'], "repeat(3, 1fr)");
+            assert.equal(styleProp['grid-template-rows'], "repeat(4, 1fr)");
+        });
         it('By default parts have no grid position defined', () => {
             let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
             assert.notExists(styleProp['grid-column']);

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -292,9 +292,11 @@ describe('Styling Properties', () => {
             assert.isTrue(currentCardView.classList.contains("grid-layout"));
         });
         it('Setting grid size', () => {
-            currentCardModel.partProperties.setPropertyNamed(currentCardModel, "grid-size", "3,4");
+            currentCardModel.partProperties.setPropertyNamed(currentCardModel, "grid-size-columns", 3);
             let styleProp = currentCardModel.partProperties.getPropertyNamed(currentCardModel, "cssStyle");
             assert.equal(styleProp['grid-template-columns'], "repeat(3, 1fr)");
+            currentCardModel.partProperties.setPropertyNamed(currentCardModel, "grid-size-rows", 4);
+            styleProp = currentCardModel.partProperties.getPropertyNamed(currentCardModel, "cssStyle");
             assert.equal(styleProp['grid-template-rows'], "repeat(4, 1fr)");
         });
         it('By default parts have no grid position defined', () => {

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -272,4 +272,39 @@ describe('Styling Properties', () => {
             assert.equal(buttonView.style['textAlign'], 'center');
         });
     });
+    describe('grid', () => {
+        let currentCardView;
+        let buttonView;
+        let buttonModel;
+        before(() => {
+            currentCardView = document.querySelector('.current-stack > .current-card');
+            buttonView = currentCardView.querySelector('st-button');
+            assert.exists(buttonView);
+            currentCardModel = currentCardView.model;
+            buttonModel = buttonView.model;
+            assert.exists(buttonModel);
+        });
+        it('By default parts have no grid position defined', () => {
+            let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
+            assert.notExists(styleProp['grid-column']);
+            assert.notExists(styleProp['grid-row']);
+        });
+        it('Setting the grid column', () => {
+            buttonModel.partProperties.setPropertyNamed(buttonModel, "grid-column", 3);
+            let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
+            assert.equal(styleProp['grid-column'], "3");
+        });
+        it('Setting the grid row', () => {
+            buttonModel.partProperties.setPropertyNamed(buttonModel, "grid-row", 3);
+            let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
+            assert.equal(styleProp['grid-row'], "3");
+        });
+        it('Can set any column / row value', () => {
+            buttonModel.partProperties.setPropertyNamed(buttonModel, "grid-row", "1 / 3");
+            buttonModel.partProperties.setPropertyNamed(buttonModel, "grid-column", "span 2");
+            let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
+            assert.equal(styleProp['grid-row'], "1 / 3");
+            assert.equal(styleProp['grid-column'], "span 2");
+        });
+    });
 });

--- a/js/objects/utils/styleProperties.js
+++ b/js/objects/utils/styleProperties.js
@@ -361,12 +361,17 @@ const addLayoutStyleProps = (target) => {
         'strict'
     );
 
-    // grid size determines the number of
-    // columns and rows for the grid.
-    // Example: N,M for N columns and M rows 
+
+    // grid num of columns or rows, for layout grid
     target.partProperties.newStyleProp(
-        'grid-size',
-        null
+        'grid-size-columns',
+        5
+    );
+
+    // grid num of columns or rows, for layout grid
+    target.partProperties.newStyleProp(
+        'grid-size-rows',
+        3
     );
 
     // list-direction specifies row or column

--- a/js/objects/utils/styleProperties.js
+++ b/js/objects/utils/styleProperties.js
@@ -361,6 +361,14 @@ const addLayoutStyleProps = (target) => {
         'strict'
     );
 
+    // grid size determines the number of
+    // columns and rows for the grid.
+    // Example: N,M for N columns and M rows 
+    target.partProperties.newStyleProp(
+        'grid-size',
+        null
+    );
+
     // list-direction specifies row or column
     // and will only have an effect whent the
     // layout property is set to 'list'

--- a/js/objects/utils/styleProperties.js
+++ b/js/objects/utils/styleProperties.js
@@ -123,6 +123,17 @@ const addPositioningStyleProps = (target) => {
         'rotate',
         null,
     );
+    // column and row represent the part's
+    // coordinate within a grid (applicable only
+    // if the parent part layout is 'grid')
+    target.partProperties.newStyleProp(
+        'grid-column',
+        null,
+    );
+    target.partProperties.newStyleProp(
+        'grid-row',
+        null,
+    );
 
     // horizontal-resizing specifies a strategy
     // for how this Part should adjust its

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -192,10 +192,10 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
         _setOrNot(styleObj, "transform",  _intToRotateDeg(propertyValue));
         break;
 
-    case "grid-size":
-        const [columnTemplate, rowTemplate] = _tupleToGrid(propertyValue);
-        _setOrNot(styleObj, "grid-template-columns", columnTemplate);
-        _setOrNot(styleObj, "grid-template-rows", rowTemplate);
+    case "grid-size-columns":
+    case "grid-size-rows":
+        const colsOrRows = propertyName.split("-")[2];
+        _setOrNot(styleObj, `grid-template-${colsOrRows}`, `repeat(${propertyValue}, 1fr)`);
         break;
 
     case "transparency":
@@ -240,17 +240,6 @@ const _intToRotateDeg = (n) => {
         }
         return `rotate(${n}deg)`;
     }
-};
-
-const _tupleToGrid = (t) => {
-    if (t !== null && t !== undefined) {
-        t = t.split(",");
-        return [
-            `repeat(${t[0].trim()}, 1fr)`,
-            `repeat(${t[1].trim()}, 1fr)`
-        ]
-    }
-    return [null, null];
 };
 
 const _intToPx = (n) => {

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -192,6 +192,12 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
         _setOrNot(styleObj, "transform",  _intToRotateDeg(propertyValue));
         break;
 
+    case "grid-size":
+        const [columnTemplate, rowTemplate] = _tupleToGrid(propertyValue);
+        _setOrNot(styleObj, "grid-template-columns", columnTemplate);
+        _setOrNot(styleObj, "grid-template-rows", rowTemplate);
+        break;
+
     case "transparency":
         _setOrNot(styleObj, "opacity",  propertyValue);
         break;
@@ -236,6 +242,16 @@ const _intToRotateDeg = (n) => {
     }
 };
 
+const _tupleToGrid = (t) => {
+    if (t !== null && t !== undefined) {
+        t = t.split(",");
+        return [
+            `repeat(${t[0].trim()}, 1fr)`,
+            `repeat(${t[1].trim()}, 1fr)`
+        ]
+    }
+    return [null, null];
+};
 
 const _intToPx = (n) => {
     if(n !== null && n !== undefined){

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -297,7 +297,6 @@ const _colorTransparencyToRGBA = (cssColor, tValue) => {
     } else {
         [r, g, b] = cssColor.match(/\d+/g);
     }
-    
     return `rgba(${r}, ${g}, ${b}, ${tValue})`;
 }
 

--- a/js/objects/views/AreaView.js
+++ b/js/objects/views/AreaView.js
@@ -8,30 +8,40 @@
  */
 import PartView from './PartView.js';
 
-const templateString = `
-                <style>
-                #area-wrapper {
-                    display: inherit;
-                    flex-direction: inherit;
-                    flex-wrap: inherit;
-                    align-items: inherit;
-                    align-content: inherit;
-                    justify-content: inherit;
-                    position: relative; 
-                    width: 100%;
-                    height: 100%;
-                    border-radius: inherit;
-                }
-                .clip {
-                    overflow: hidden;  
-                }
-                .allow-scroll {
-                    overflow: auto;
-                }
-                </style>
-                <div id="area-wrapper">
-                <slot></slot>
-                </div>
+const templateString = /* html */`
+<style>
+    :host(.grid-layout) > #area-wrapper {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        grid-template-rows: repeat(3, 1fr);
+    }
+
+    :host(.grid-layout) > #area-wrapper > * {
+        place-self: center;
+    }
+
+    #area-wrapper {
+        display: inherit;
+        flex-direction: inherit;
+        flex-wrap: inherit;
+        align-items: inherit;
+        align-content: inherit;
+        justify-content: inherit;
+        position: relative; 
+        width: 100%;
+        height: 100%;
+        border-radius: inherit;
+    }
+    .clip {
+        overflow: hidden;  
+    }
+    .allow-scroll {
+        overflow: auto;
+    }
+</style>
+<div id="area-wrapper">
+<slot></slot>
+</div>
 `;
 
 class AreaView extends PartView {
@@ -100,28 +110,28 @@ class AreaView extends PartView {
             this.model,
             'list-direction'
         );
-        if(layout != 'list'){
-            contextMenu.addListItem(
-                "Set Layout to List",
+        // Now we construct the submenu for toggling layouts
+        let submenu = document.createElement('st-context-menu');
+        submenu.hideHeader();
+        ['strict', 'list', 'grid'].forEach((option) => {
+            submenu.addListItem(
+                `Set Layout to ${option[0].toUpperCase() + option.slice(1)}`,
                 (event) => {
                     this.model.partProperties.setPropertyNamed(
                         this.model,
                         'layout',
-                        'list'
+                        option
                     );
                 }
             );
-        } else {
-            contextMenu.addListItem(
-                "Set Layout to Strict",
-                (event) => {
-                    this.model.partProperties.setPropertyNamed(
-                        this.model,
-                        'layout',
-                        'strict'
-                    );
-                }
-            );
+        })
+        contextMenu.addListItem(
+            'Select a layout',
+            null,
+            submenu
+        );
+
+        if(layout == 'list'){
             if(direction == 'row'){
                 contextMenu.addListItem(
                     "Set List Direction to Column",

--- a/js/objects/views/AreaView.js
+++ b/js/objects/views/AreaView.js
@@ -12,8 +12,8 @@ const templateString = /* html */`
 <style>
     :host(.grid-layout) > #area-wrapper {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        grid-template-rows: repeat(3, 1fr);
+        grid-template-columns: inherit;
+        grid-template-rows: inherit;
     }
 
     :host(.grid-layout) > #area-wrapper > * {

--- a/js/objects/views/CardView.js
+++ b/js/objects/views/CardView.js
@@ -7,9 +7,9 @@
 import PartView from './PartView.js';
 
 const templateString = `
-                <style>
-                </style>
-                <slot></slot>
+<style>
+</style>
+<slot></slot>
 `;
 
 class CardView extends PartView {
@@ -68,6 +68,60 @@ class CardView extends PartView {
                     "Hide Toolbox",
                     (event) => {
                         toolbox.partProperties.setPropertyNamed(toolbox, "hide", true);
+                    }
+                );
+            }
+        }
+        let layout = this.model.partProperties.getPropertyNamed(
+            this.model,
+            'layout'
+        );
+        let direction = this.model.partProperties.getPropertyNamed(
+            this.model,
+            'list-direction'
+        );
+        // Now we construct the submenu for toggling layouts
+        let submenu = document.createElement('st-context-menu');
+        submenu.hideHeader();
+        ['strict', 'list', 'grid'].forEach((option) => {
+            submenu.addListItem(
+                `Set Layout to ${option[0].toUpperCase() + option.slice(1)}`,
+                (event) => {
+                    this.model.partProperties.setPropertyNamed(
+                        this.model,
+                        'layout',
+                        option
+                    );
+                }
+            );
+        })
+        contextMenu.addListItem(
+            'Select a layout',
+            null,
+            submenu
+        );
+
+        if(layout == 'list'){
+            if(direction == 'row'){
+                contextMenu.addListItem(
+                    "Set List Direction to Column",
+                    (event) => {
+                        this.model.partProperties.setPropertyNamed(
+                            this.model,
+                            'list-direction',
+                            'column'
+                        );
+                    }
+                );
+            } else {
+                contextMenu.addListItem(
+                    "Set List Direction to Row",
+                    (event) => {
+                        this.model.partProperties.setPropertyNamed(
+                            this.model,
+                            'list-direction',
+                            'row'
+                        );
                     }
                 );
             }

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -426,10 +426,12 @@ class PartView extends HTMLElement {
     }
 
     layoutChanged(value, partId) {
+        // clear out all layout classes first
+        this.classList.remove('list-layout', 'grid-layout');
         if (value == 'list') {
             this.classList.add('list-layout');
-        } else {
-            this.classList.remove('list-layout');
+        } else if (value == 'grid') {
+            this.classList.add('grid-layout');
         }
     }
 


### PR DESCRIPTION
### Main Points ###

This PR adds grid layouts. Currently these apply to cards and area. 

A layout part (such as area/card) layout now takes the "grid" value, and have new properties `grid-size-columns` and `grid-size-rows` (default 3x5). You can set layout to grid in the editor or in the context menu like so:
![image](https://github.com/dkrasner/Simpletalk/assets/1154326/a5b03fdb-c08f-4c92-a847-2a46a97feddf)


Note: i have updated the context menu to better display and respond to various layout options, so play around and let me know... 

A layout sub-part, ie something contained in an area/card, have `grid-column` and `grid-row` properties. These allow the element to set itself in a specific row or column. If these are not set then the default is to put the part in the first available grid cell (this is what the DOM/css default is as well and I think makes sense here). 

For example, here the buttons are set in cells 1,1 and 5,3 respectively on a 5,3 col,row grid. 

![image](https://github.com/dkrasner/Simpletalk/assets/1154326/cc0a9c19-2b18-4878-908f-68072b109729)

####Tests

Basic styler related tests [have been added](https://github.com/dkrasner/Simpletalk/compare/wysiwyg...daniel-area-grid?expand=1#diff-25292789e9ff4918d11c803e6d5b80527476b7f505c1bfcf0552256ef3f5e87aR275)


#### ISSUES
We want something similar to the dev tools grid layout hinter, like so
![image](https://github.com/dkrasner/Simpletalk/assets/1154326/b7365d9d-a59c-474c-b4cd-70df306374a4)

as well as snapping to grid-cells, as described in #147 issue. 

There is a bug #150 related to initial load for Card and cssStyle/properties. 

