### PR TITLE
Lock

### DIFF
--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -242,7 +242,11 @@ class Part {
                         el.model.partProperties.setPropertyNamed(el.model, "halo-open", false);
                     });
                 }
-                propObject._value = val;
+                // check to see if this is an editable world
+                const world = window.System.partsById['world'];
+                if (!world.partProperties.getPropertyNamed('world', "lock")) {
+                    propObject._value = val;
+                }
             },
             function(propOwner, propObject){
                 return propObject._value;
@@ -266,7 +270,11 @@ class Part {
                         });
                     }
                 }
-                propObject._value = val;
+                // check to see if this is an editable world
+                const world = window.System.partsById['world'];
+                if (!world.partProperties.getPropertyNamed('world', "lock")) {
+                    propObject._value = val;
+                }
             },
             function(propOwner, propObject){
                 return propObject._value;

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -192,6 +192,10 @@ class Part {
                 false
             ),
             new BasicProperty(
+                'wants-context-menu',
+                true
+            ),
+            new BasicProperty(
                 'id',
                 idMaker.new()
             ),

--- a/js/objects/parts/WorldStack.js
+++ b/js/objects/parts/WorldStack.js
@@ -55,10 +55,21 @@ class WorldStack extends Part {
             )
         );
 
+        // if the 'lock' prop is set to true then no editors
+        // can be opened (context-menu, side editor etc); nor can you run do it
+        // commands
+        this.partProperties.addProperty(
+            new BasicProperty(
+                "lock",
+                false
+            )
+        );
+
         // private command handlers
         this.setPrivateCommandHandler("openNavigator", () => {
             this.partProperties.setPropertyNamed(this, "navigator-open", true);
         });
+
         this.setPrivateCommandHandler("closeNavigator", () => {
             this.partProperties.setPropertyNamed(this, "navigator-open", false);
         });

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -402,6 +402,7 @@ class FieldView extends PartView {
         // clear all selections
         this.selectionRanges = {};
     }
+    
     onClick(event){
         event.preventDefault();
         event.stopPropagation();
@@ -413,13 +414,17 @@ class FieldView extends PartView {
                 let text = window.getSelection().toString();
                 // if no text is selected we do nothing
                 if(text){
+                    // check to see if this is an editable world
+                    const world = window.System.partsById['world'];
+                    const locked = world.partProperties.getPropertyNamed('world', "lock");
                     // if the altKey is pressed we open the context ("do it") menu
-                    if(event.altKey){
+                    if(event.altKey && !locked){
                         if(!this.contextMenuOpen){
                             this.openContextMenu();
                         }
                     } else {
-                        this.handleSelection(event.metaKey);
+                        // TODO this was never truly tested
+                        // this.handleSelection(event.metaKey);
                     }
                 } else {
                     // make sure no context menu is open

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -102,7 +102,6 @@ class FieldView extends PartView {
         this.contextMenuOpen = false;
         this.haloLockUnlockButton = null;
         this.selectionRanges = {};
-        this.wantsContextMenu = false;
 
         // Presets for syntax highlighting.
         // When highlighting is enabled, we will check

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -40,8 +40,6 @@ class PartView extends HTMLElement {
 
         // Note: see getter for wantsHaloMove
 
-        // Context menu settings
-        this.wantsContextMenu = true;
 
         // Bind component methods
         this.setModel = this.setModel.bind(this);
@@ -856,9 +854,10 @@ class PartView extends HTMLElement {
     }
 
     onContextMenuClick(event) {
-        if (this.wantsContextMenu) {
-            event.preventDefault();
-            event.stopPropagation();
+        // we always prevent default ie the browser context menu
+        event.preventDefault();
+        event.stopPropagation();
+        if (this.model.partProperties.getPropertyNamed(this.model, "wants-context-menu")) {
             if (this.contextMenuIsOpen) {
                 this.closeContextMenu();
             } else {

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -857,7 +857,12 @@ class PartView extends HTMLElement {
         // we always prevent default ie the browser context menu
         event.preventDefault();
         event.stopPropagation();
-        if (this.model.partProperties.getPropertyNamed(this.model, "wants-context-menu")) {
+        // check to see if this is an editable world
+        const world = window.System.partsById['world'];
+        const locked = world.partProperties.getPropertyNamed('world', "lock");
+        // make sure the world is not locked and the context menu is accepted
+        const wantsCM = this.model.partProperties.getPropertyNamed(this.model, "wants-context-menu");
+        if (!locked && wantsCM) {
             if (this.contextMenuIsOpen) {
                 this.closeContextMenu();
             } else {
@@ -891,7 +896,10 @@ class PartView extends HTMLElement {
     }
 
     onHaloActivationClick(event) {
-        if (this.wantsHalo) {
+        // check to see if this is an editable world
+        const world = window.System.partsById['world'];
+        const locked = world.partProperties.getPropertyNamed('world', "lock");
+        if (!locked && this.wantsHalo) {
             if (this.hasOpenHalo) {
                 this.model.partProperties.setPropertyNamed(this.model, "halo-open", false);
             } else {

--- a/wysiwyg.html
+++ b/wysiwyg.html
@@ -1,10 +1,10 @@
 <html xmlns="http://www.w3.org/1999/xhtml"><head>
     <meta charset="utf-8">
-    <title>System Object Example</title>
+    <title>wysiwyg</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
     <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&amp;display=swap" rel="stylesheet"> 
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="./css/core.css">
     <script src="./js/ohm/simpletalk.ohm" type="text/ohm-js"></script>
     <script src="./js/objects/build/devSystem.bundle.js"></script>
@@ -37,47 +37,47 @@
             "id": "world",
             "properties": {
                 "id": "world",
-                "name": "",
+                "name": "wysiwyg",
                 "script": "",
                 "cssStyle": {},
                 "cssTextStyle": {},
                 "number": 1,
                 "custom-properties": {},
                 "stepping": false,
-                "current": "cf14d92c021a45a2a10e90702ccfb5f8"
+                "current": "9cabb0b4c7634714b2d46df391ac4c59"
             },
             "subparts": [
-                "cf14d92c021a45a2a10e90702ccfb5f8"
+                "9cabb0b4c7634714b2d46df391ac4c59"
             ],
             "ownerId": null,
             "loadedStacks": [
-                "cf14d92c021a45a2a10e90702ccfb5f8"
+                "9cabb0b4c7634714b2d46df391ac4c59"
             ]
         },
-        "cf14d92c021a45a2a10e90702ccfb5f8": {
+        "9cabb0b4c7634714b2d46df391ac4c59": {
             "type": "stack",
-            "id": "cf14d92c021a45a2a10e90702ccfb5f8",
+            "id": "9cabb0b4c7634714b2d46df391ac4c59",
             "properties": {
-                "id": "cf14d92c021a45a2a10e90702ccfb5f8",
+                "id": "9cabb0b4c7634714b2d46df391ac4c59",
                 "name": "",
                 "cssStyle": {},
                 "cssTextStyle": {},
                 "number": 1,
                 "custom-properties": {},
                 "stepping": false,
-                "current": "7a5816d9059f46babef678818bcc584c"
+                "current": "a5b46914830a40a680cad6acc1340f86"
             },
             "subparts": [
-                "7a5816d9059f46babef678818bcc584c",
-                "9c876cd49d8b4fa5a6e6e5f12b5ee6dd"
+                "a5b46914830a40a680cad6acc1340f86",
+                "909dbda791d5486eb3f90c2f46f9f709"
             ],
             "ownerId": "world"
         },
-        "7a5816d9059f46babef678818bcc584c": {
+        "a5b46914830a40a680cad6acc1340f86": {
             "type": "card",
-            "id": "7a5816d9059f46babef678818bcc584c",
+            "id": "a5b46914830a40a680cad6acc1340f86",
             "properties": {
-                "id": "7a5816d9059f46babef678818bcc584c",
+                "id": "a5b46914830a40a680cad6acc1340f86",
                 "name": "",
                 "script": "on openCard \n\tgetBrowserName\n\n\tif it != \"Firefox\"\n\tthen \n\t\tsendWarning\n\tend if\n\nend openCard \n\n\non sendWarning \n\tanswer \"I am an experimental system, please try me in Firefox\"\n\nend sendWarning ",
                 "cssStyle": {
@@ -111,13 +111,13 @@
                 "stepping": false
             },
             "subparts": [],
-            "ownerId": "cf14d92c021a45a2a10e90702ccfb5f8"
+            "ownerId": "9cabb0b4c7634714b2d46df391ac4c59"
         },
-        "9c876cd49d8b4fa5a6e6e5f12b5ee6dd": {
+        "909dbda791d5486eb3f90c2f46f9f709": {
             "type": "window",
-            "id": "9c876cd49d8b4fa5a6e6e5f12b5ee6dd",
+            "id": "909dbda791d5486eb3f90c2f46f9f709",
             "properties": {
-                "id": "9c876cd49d8b4fa5a6e6e5f12b5ee6dd",
+                "id": "909dbda791d5486eb3f90c2f46f9f709",
                 "name": "Toolbox",
                 "cssStyle": {
                     "backgroundColor": "rgba(0, 151, 167, 0)",
@@ -161,15 +161,15 @@
                 "pinning": ""
             },
             "subparts": [
-                "8d61e54bf9524b69982f5586bd92c6d1"
+                "8adf30b92f4c457b91c051fb7b7795c6"
             ],
-            "ownerId": "cf14d92c021a45a2a10e90702ccfb5f8"
+            "ownerId": "9cabb0b4c7634714b2d46df391ac4c59"
         },
-        "8d61e54bf9524b69982f5586bd92c6d1": {
+        "8adf30b92f4c457b91c051fb7b7795c6": {
             "type": "area",
-            "id": "8d61e54bf9524b69982f5586bd92c6d1",
+            "id": "8adf30b92f4c457b91c051fb7b7795c6",
             "properties": {
-                "id": "8d61e54bf9524b69982f5586bd92c6d1",
+                "id": "8adf30b92f4c457b91c051fb7b7795c6",
                 "name": "",
                 "cssStyle": {
                     "width": "187px",
@@ -217,25 +217,25 @@
                 "list-alignment": "center"
             },
             "subparts": [
-                "acfccac5d60542018a5a5c0538f18e4b",
-                "dcd35b9b9c9147d3b8981b38e258e6e2",
-                "e532adf6096f40f0b5e9e6804c733b42",
-                "3e64d701f7eb4ca9881f229ec3687f3d",
-                "26b5259c303043bdab497bfb1b4e61fc",
-                "bfaa1c6f1ab94deabd6c2be4b2236f40",
-                "56a05b92e9bd4c598403880abf6a49c4",
-                "1514204d36fc4dfcb3ceaeb3c58c629f",
-                "4bd7a9ce06e249cfb09f958d132b8e77",
-                "cb159758a4174afbb232f24eac5be72d",
-                "3a3c892eae1c4288ab550bc4cf655895"
+                "b25e6f461bc0495e9d7a55f79ff28d5f",
+                "62919d7450ba4aa1b3662e58f6dce3ef",
+                "ac93f6a4c0434f6a860af8744ae5aa2f",
+                "d87fe98081a94724aa4118bc5bb40e1b",
+                "9b862e0843d843cbbf2bdbcc3166d39e",
+                "4787b001cbf94991b52f20932585e80a",
+                "240c99902b9d4211a7ba7116fe93e89d",
+                "4188cbbd66ef4927a8ca1f3e7aadd21a",
+                "adfd244384b54a8eaba18ae718d50d2e",
+                "1c1633669db946f38002a7a33736a340",
+                "409373e5c2b1443a939641e6e272a8a8"
             ],
-            "ownerId": "9c876cd49d8b4fa5a6e6e5f12b5ee6dd"
+            "ownerId": "909dbda791d5486eb3f90c2f46f9f709"
         },
-        "acfccac5d60542018a5a5c0538f18e4b": {
+        "b25e6f461bc0495e9d7a55f79ff28d5f": {
             "type": "button",
-            "id": "acfccac5d60542018a5a5c0538f18e4b",
+            "id": "b25e6f461bc0495e9d7a55f79ff28d5f",
             "properties": {
-                "id": "acfccac5d60542018a5a5c0538f18e4b",
+                "id": "b25e6f461bc0495e9d7a55f79ff28d5f",
                 "name": "Add Button",
                 "script": "on click\n\tadd button to current card\nend click\n",
                 "cssStyle": {
@@ -282,13 +282,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         },
-        "dcd35b9b9c9147d3b8981b38e258e6e2": {
+        "62919d7450ba4aa1b3662e58f6dce3ef": {
             "type": "button",
-            "id": "dcd35b9b9c9147d3b8981b38e258e6e2",
+            "id": "62919d7450ba4aa1b3662e58f6dce3ef",
             "properties": {
-                "id": "dcd35b9b9c9147d3b8981b38e258e6e2",
+                "id": "62919d7450ba4aa1b3662e58f6dce3ef",
                 "name": "Add Image",
                 "script": "on click\n\tadd image to current card\nend click",
                 "cssStyle": {
@@ -337,13 +337,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         },
-        "e532adf6096f40f0b5e9e6804c733b42": {
+        "ac93f6a4c0434f6a860af8744ae5aa2f": {
             "type": "button",
-            "id": "e532adf6096f40f0b5e9e6804c733b42",
+            "id": "ac93f6a4c0434f6a860af8744ae5aa2f",
             "properties": {
-                "id": "e532adf6096f40f0b5e9e6804c733b42",
+                "id": "ac93f6a4c0434f6a860af8744ae5aa2f",
                 "name": "Add Drawing",
                 "script": "on click\n\tadd drawing to current card\nend click",
                 "cssStyle": {
@@ -392,13 +392,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         },
-        "3e64d701f7eb4ca9881f229ec3687f3d": {
+        "d87fe98081a94724aa4118bc5bb40e1b": {
             "type": "button",
-            "id": "3e64d701f7eb4ca9881f229ec3687f3d",
+            "id": "d87fe98081a94724aa4118bc5bb40e1b",
             "properties": {
-                "id": "3e64d701f7eb4ca9881f229ec3687f3d",
+                "id": "d87fe98081a94724aa4118bc5bb40e1b",
                 "name": "Add Area",
                 "script": "on click\n\tadd area to current card\nend click",
                 "cssStyle": {
@@ -447,13 +447,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         },
-        "26b5259c303043bdab497bfb1b4e61fc": {
+        "9b862e0843d843cbbf2bdbcc3166d39e": {
             "type": "button",
-            "id": "26b5259c303043bdab497bfb1b4e61fc",
+            "id": "9b862e0843d843cbbf2bdbcc3166d39e",
             "properties": {
-                "id": "26b5259c303043bdab497bfb1b4e61fc",
+                "id": "9b862e0843d843cbbf2bdbcc3166d39e",
                 "name": "Add Field",
                 "script": "on click\n\tadd field to current card\nend click",
                 "cssStyle": {
@@ -502,13 +502,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         },
-        "bfaa1c6f1ab94deabd6c2be4b2236f40": {
+        "4787b001cbf94991b52f20932585e80a": {
             "type": "button",
-            "id": "bfaa1c6f1ab94deabd6c2be4b2236f40",
+            "id": "4787b001cbf94991b52f20932585e80a",
             "properties": {
-                "id": "bfaa1c6f1ab94deabd6c2be4b2236f40",
+                "id": "4787b001cbf94991b52f20932585e80a",
                 "name": "Add Card",
                 "script": "on click\n\tadd card\nend click",
                 "cssStyle": {
@@ -557,13 +557,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         },
-        "56a05b92e9bd4c598403880abf6a49c4": {
+        "240c99902b9d4211a7ba7116fe93e89d": {
             "type": "button",
-            "id": "56a05b92e9bd4c598403880abf6a49c4",
+            "id": "240c99902b9d4211a7ba7116fe93e89d",
             "properties": {
-                "id": "56a05b92e9bd4c598403880abf6a49c4",
+                "id": "240c99902b9d4211a7ba7116fe93e89d",
                 "name": "Add Toolbox Button",
                 "script": "on click\n\tadd button\n\ttell last button to set \"width\" to \"fill\"\nend click",
                 "cssStyle": {
@@ -611,13 +611,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         },
-        "1514204d36fc4dfcb3ceaeb3c58c629f": {
+        "4188cbbd66ef4927a8ca1f3e7aadd21a": {
             "type": "button",
-            "id": "1514204d36fc4dfcb3ceaeb3c58c629f",
+            "id": "4188cbbd66ef4927a8ca1f3e7aadd21a",
             "properties": {
-                "id": "1514204d36fc4dfcb3ceaeb3c58c629f",
+                "id": "4188cbbd66ef4927a8ca1f3e7aadd21a",
                 "name": "Import World",
                 "script": "on click\n\timportWorld\nend click",
                 "cssStyle": {
@@ -666,15 +666,15 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         },
-        "4bd7a9ce06e249cfb09f958d132b8e77": {
+        "adfd244384b54a8eaba18ae718d50d2e": {
             "type": "button",
-            "id": "4bd7a9ce06e249cfb09f958d132b8e77",
+            "id": "adfd244384b54a8eaba18ae718d50d2e",
             "properties": {
-                "id": "4bd7a9ce06e249cfb09f958d132b8e77",
+                "id": "adfd244384b54a8eaba18ae718d50d2e",
                 "name": "Import Local World",
-                "script": "on click \n\timportLocalWorld\nend click ",
+                "script": "on click \n\ttell this world to import\nend click ",
                 "cssStyle": {
                     "backgroundColor": "rgba(0, 151, 167, 1)",
                     "opacity": 1,
@@ -722,15 +722,15 @@
                 "text-size": "15"
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         },
-        "cb159758a4174afbb232f24eac5be72d": {
+        "1c1633669db946f38002a7a33736a340": {
             "type": "button",
-            "id": "cb159758a4174afbb232f24eac5be72d",
+            "id": "1c1633669db946f38002a7a33736a340",
             "properties": {
-                "id": "cb159758a4174afbb232f24eac5be72d",
+                "id": "1c1633669db946f38002a7a33736a340",
                 "name": "Save",
-                "script": "on click\n\tif the \"name\" of this world == \"\"\n\tthen\n\t\task \"Please name me first\"\n\t\tput it into name\n\t\ttell this world to set \"name\" to name\n\t\tsaveHTML name\n\telse\n\t\tsaveHTML\n\tend if\n\nend click\n",
+                "script": "on click \n\tif the \"name\" of this world == \"\"\n\tthen\n\t\task \"Please name me first\"\n\t\tput it into name\n\t\ttell this world to set \"name\" to name\n\t\ttell this world to save name\n\telse\n\t\ttell this world to save\n\tend if\n\nend click \n",
                 "cssStyle": {
                     "backgroundColor": "rgba(0, 151, 167, 1)",
                     "opacity": 1,
@@ -754,7 +754,7 @@
                     "border-bottom-right-radius": "3px",
                     "display": null,
                     "top": "0px",
-                    "left": "0px",
+                    "left": "1px",
                     "horizontal-resizing": "rigid",
                     "vertical-resizing": "rigid",
                     "width": "100%"
@@ -772,18 +772,19 @@
                 "custom-properties": {},
                 "stepping": false,
                 "width": "fill",
+                "left": 1,
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         },
-        "3a3c892eae1c4288ab550bc4cf655895": {
+        "409373e5c2b1443a939641e6e272a8a8": {
             "type": "button",
-            "id": "3a3c892eae1c4288ab550bc4cf655895",
+            "id": "409373e5c2b1443a939641e6e272a8a8",
             "properties": {
-                "id": "3a3c892eae1c4288ab550bc4cf655895",
+                "id": "409373e5c2b1443a939641e6e272a8a8",
                 "name": "Save As",
-                "script": "on click \n\task \"What is my Name\"\n\tsaveHTML it\nend click ",
+                "script": "on click \n\task \"What is my Name\"\n\ttell this world to save it\nend click ",
                 "cssStyle": {
                     "backgroundColor": "rgba(0, 151, 167, 1)",
                     "opacity": 1,
@@ -831,7 +832,7 @@
                 "text-size": "15"
             },
             "subparts": [],
-            "ownerId": "8d61e54bf9524b69982f5586bd92c6d1"
+            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
         }
     }
 }</script>
@@ -840,4 +841,78 @@
 
 
 
-<st-editor class=""><editor-props-list tab-name="properties" class="show-pane"><editor-prop-item name="background-color" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="background-transparency" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-bottom-color" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-bottom-style" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-bottom-transparency" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-bottom-width" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-left-color" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-left-style" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-left-transparency" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-left-width" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-right-color" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-right-style" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-right-transparency" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-right-width" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-top-color" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-top-style" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-top-transparency" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="border-top-width" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="bottom-margin" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="contents" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="corner-bottom-left-round" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="corner-bottom-right-round" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="corner-top-left-round" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="corner-top-right-round" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="editor-open" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="enabled" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="halo-open" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="height" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="hide" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="horizontal-resizing" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="left" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="left-margin" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="number" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="pinning" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="pinning-bottom" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="pinning-left" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="pinning-right" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="pinning-top" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="rectangle" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="right-margin" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="rotate" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="selectedText" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="shadow-blur" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="shadow-color" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="shadow-left" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="shadow-spread" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="shadow-top" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="shadow-transparency" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="stepping" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="stepTime" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="text-align" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="text-bold" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="text-color" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="text-font" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="text-italic" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="text-size" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="text-style" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="text-transparency" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="top" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="top-margin" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="transparency" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="vertical-resizing" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="wants-move" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item><editor-prop-item name="width" owner-id="3a3c892eae1c4288ab550bc4cf655895"></editor-prop-item></editor-props-list><editor-messenger tab-name="messenger"></editor-messenger><editor-custom-list tab-name="custom"></editor-custom-list><editor-subparts tab-name="subparts"><editor-location-info slot="ancestor-info" kind="stack" ref-id="cf14d92c021a45a2a10e90702ccfb5f8"></editor-location-info><editor-location-info slot="ancestor-info" kind="card" class="hidden"></editor-location-info><editor-location-info slot="ancestor-info" kind="owner" ref-id="8d61e54bf9524b69982f5586bd92c6d1"></editor-location-info></editor-subparts></st-editor></body></html>
+
+<st-editor class="open"><editor-props-list tab-name="properties" class=""><editor-prop-item name="background-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="background-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-bottom-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-bottom-style" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-bottom-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-bottom-width" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-left-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-left-style" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-left-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-left-width" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-right-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-right-style" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-right-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-right-width" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-top-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-top-style" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-top-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-top-width" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="bottom-padding" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="cantDelete" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="contents" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="corner-bottom-left-round" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="corner-bottom-right-round" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="corner-top-left-round" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="corner-top-right-round" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="dontSearch" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="editor-open" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="enabled" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="grid-size-columns" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="grid-size-rows" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="layout" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="left-padding" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="list-alignment" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="list-direction" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="list-distribution" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="list-wrapping" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="marked" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="number" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="rectangle" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="right-padding" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-blur" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-left" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-spread" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-top" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="showPict" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="stepping" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="stepTime" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="top-padding" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="wants-move" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item></editor-props-list><editor-messenger tab-name="messenger" class="show-pane"></editor-messenger><editor-custom-list tab-name="custom"></editor-custom-list><editor-subparts tab-name="subparts"><editor-location-info slot="ancestor-info" kind="stack" ref-id="9cabb0b4c7634714b2d46df391ac4c59"></editor-location-info><editor-location-info slot="ancestor-info" kind="card" class="hidden"></editor-location-info><editor-location-info slot="ancestor-info" kind="owner" ref-id="9cabb0b4c7634714b2d46df391ac4c59"></editor-location-info><button slot="button" data-type="window" title="Add a window to this card" class="add-part-button">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-window" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <path d="M12 3c-3.866 0 -7 3.272 -7 7v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1 -1v-10c0 -3.728 -3.134 -7 -7 -7z"></path>
+  <line x1="5" y1="13" x2="19" y2="13"></line>
+  <line x1="12" y1="3" x2="12" y2="21"></line>
+</svg>
+</button><button slot="button" data-type="button" title="Add a button to this card" class="add-part-button">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-hand-finger" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <path d="M8 13v-8.5a1.5 1.5 0 0 1 3 0v7.5"></path>
+  <path d="M11 11.5v-2a1.5 1.5 0 1 1 3 0v2.5"></path>
+  <path d="M14 10.5a1.5 1.5 0 0 1 3 0v1.5"></path>
+  <path d="M17 11.5a1.5 1.5 0 0 1 3 0v4.5a6 6 0 0 1 -6 6h-2h.208a6 6 0 0 1 -5.012 -2.7a69.74 69.74 0 0 1 -.196 -.3c-.312 -.479 -1.407 -2.388 -3.286 -5.728a1.5 1.5 0 0 1 .536 -2.022a1.867 1.867 0 0 1 2.28 .28l1.47 1.47"></path>
+</svg>
+</button><button slot="button" data-type="field" title="Add a field to this card" class="add-part-button">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-forms" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <path d="M12 3a3 3 0 0 0 -3 3v12a3 3 0 0 0 3 3"></path>
+  <path d="M6 3a3 3 0 0 1 3 3v12a3 3 0 0 1 -3 3"></path>
+  <path d="M13 7h7a1 1 0 0 1 1 1v8a1 1 0 0 1 -1 1h-7"></path>
+  <path d="M5 7h-1a1 1 0 0 0 -1 1v8a1 1 0 0 0 1 1h1"></path>
+  <path d="M17 12h.01"></path>
+  <path d="M13 12h.01"></path>
+</svg>
+</button><button slot="button" data-type="area" title="Add a area to this card" class="add-part-button">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-shape" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <circle cx="5" cy="5" r="2"></circle>
+  <circle cx="19" cy="5" r="2"></circle>
+  <circle cx="5" cy="19" r="2"></circle>
+  <circle cx="19" cy="19" r="2"></circle>
+  <line x1="5" y1="7" x2="5" y2="17"></line>
+  <line x1="7" y1="5" x2="17" y2="5"></line>
+  <line x1="7" y1="19" x2="17" y2="19"></line>
+  <line x1="19" y1="7" x2="19" y2="17"></line>
+</svg>
+</button><button slot="button" data-type="drawing" title="Add a drawing to this card" class="add-part-button">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-palette" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <path d="M12 21a9 9 0 1 1 0 -18a9 8 0 0 1 9 8a4.5 4 0 0 1 -4.5 4h-2.5a2 2 0 0 0 -1 3.75a1.3 1.3 0 0 1 -1 2.25"></path>
+  <circle cx="7.5" cy="10.5" r=".5" fill="currentColor"></circle>
+  <circle cx="12" cy="7.5" r=".5" fill="currentColor"></circle>
+  <circle cx="16.5" cy="10.5" r=".5" fill="currentColor"></circle>
+</svg>
+</button><button slot="button" data-type="image" title="Add a image to this card" class="add-part-button">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-photo" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <line x1="15" y1="8" x2="15.01" y2="8"></line>
+  <rect x="4" y="4" width="16" height="16" rx="3"></rect>
+  <path d="M4 15l4 -4a3 5 0 0 1 3 0l5 5"></path>
+  <path d="M14 14l1 -1a3 5 0 0 1 3 0l2 2"></path>
+</svg>
+</button><button slot="button" data-type="audio" title="Add a audio to this card" class="add-part-button">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-puzzle" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <path d="M4 7h3a1 1 0 0 0 1 -1v-1a2 2 0 0 1 4 0v1a1 1 0 0 0 1 1h3a1 1 0 0 1 1 1v3a1 1 0 0 0 1 1h1a2 2 0 0 1 0 4h-1a1 1 0 0 0 -1 1v3a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-1a2 2 0 0 0 -4 0v1a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h1a2 2 0 0 0 0 -4h-1a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1"></path>
+</svg>
+</button><button slot="button" data-type="video" title="Add a video to this card" class="add-part-button">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-puzzle" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <path d="M4 7h3a1 1 0 0 0 1 -1v-1a2 2 0 0 1 4 0v1a1 1 0 0 0 1 1h3a1 1 0 0 1 1 1v3a1 1 0 0 0 1 1h1a2 2 0 0 1 0 4h-1a1 1 0 0 0 -1 1v3a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-1a2 2 0 0 0 -4 0v1a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h1a2 2 0 0 0 0 -4h-1a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1"></path>
+</svg>
+</button><button slot="button" data-type="browser" title="Add a browser to this card" class="add-part-button">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-puzzle" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <path d="M4 7h3a1 1 0 0 0 1 -1v-1a2 2 0 0 1 4 0v1a1 1 0 0 0 1 1h3a1 1 0 0 1 1 1v3a1 1 0 0 0 1 1h1a2 2 0 0 1 0 4h-1a1 1 0 0 0 -1 1v3a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-1a2 2 0 0 0 -4 0v1a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h1a2 2 0 0 0 0 -4h-1a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1"></path>
+</svg>
+</button><button slot="button" data-type="resource" title="Add a resource to this card" class="add-part-button">
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-puzzle" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="#2c3e50" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+  <path d="M4 7h3a1 1 0 0 0 1 -1v-1a2 2 0 0 1 4 0v1a1 1 0 0 0 1 1h3a1 1 0 0 1 1 1v3a1 1 0 0 0 1 1h1a2 2 0 0 1 0 4h-1a1 1 0 0 0 -1 1v3a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-1a2 2 0 0 0 -4 0v1a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h1a2 2 0 0 0 0 -4h-1a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1"></path>
+</svg>
+</button></editor-subparts></st-editor></body></html>

--- a/wysiwyg.html
+++ b/wysiwyg.html
@@ -44,40 +44,40 @@
                 "number": 1,
                 "custom-properties": {},
                 "stepping": false,
-                "current": "9cabb0b4c7634714b2d46df391ac4c59"
+                "current": "90cecb014285422d835eac5b35c62a0c"
             },
             "subparts": [
-                "9cabb0b4c7634714b2d46df391ac4c59"
+                "90cecb014285422d835eac5b35c62a0c"
             ],
             "ownerId": null,
             "loadedStacks": [
-                "9cabb0b4c7634714b2d46df391ac4c59"
+                "90cecb014285422d835eac5b35c62a0c"
             ]
         },
-        "9cabb0b4c7634714b2d46df391ac4c59": {
+        "90cecb014285422d835eac5b35c62a0c": {
             "type": "stack",
-            "id": "9cabb0b4c7634714b2d46df391ac4c59",
+            "id": "90cecb014285422d835eac5b35c62a0c",
             "properties": {
-                "id": "9cabb0b4c7634714b2d46df391ac4c59",
+                "id": "90cecb014285422d835eac5b35c62a0c",
                 "name": "",
                 "cssStyle": {},
                 "cssTextStyle": {},
                 "number": 1,
                 "custom-properties": {},
                 "stepping": false,
-                "current": "a5b46914830a40a680cad6acc1340f86"
+                "current": "2477200f50f54a0780442baf89451f6f"
             },
             "subparts": [
-                "a5b46914830a40a680cad6acc1340f86",
-                "909dbda791d5486eb3f90c2f46f9f709"
+                "2477200f50f54a0780442baf89451f6f",
+                "34bd357bcea3455ab1a159108b938a40"
             ],
             "ownerId": "world"
         },
-        "a5b46914830a40a680cad6acc1340f86": {
+        "2477200f50f54a0780442baf89451f6f": {
             "type": "card",
-            "id": "a5b46914830a40a680cad6acc1340f86",
+            "id": "2477200f50f54a0780442baf89451f6f",
             "properties": {
-                "id": "a5b46914830a40a680cad6acc1340f86",
+                "id": "2477200f50f54a0780442baf89451f6f",
                 "name": "",
                 "script": "on openCard \n\tgetBrowserName\n\n\tif it != \"Firefox\"\n\tthen \n\t\tsendWarning\n\tend if\n\nend openCard \n\n\non sendWarning \n\tanswer \"I am an experimental system, please try me in Firefox\"\n\nend sendWarning ",
                 "cssStyle": {
@@ -111,13 +111,13 @@
                 "stepping": false
             },
             "subparts": [],
-            "ownerId": "9cabb0b4c7634714b2d46df391ac4c59"
+            "ownerId": "90cecb014285422d835eac5b35c62a0c"
         },
-        "909dbda791d5486eb3f90c2f46f9f709": {
+        "34bd357bcea3455ab1a159108b938a40": {
             "type": "window",
-            "id": "909dbda791d5486eb3f90c2f46f9f709",
+            "id": "34bd357bcea3455ab1a159108b938a40",
             "properties": {
-                "id": "909dbda791d5486eb3f90c2f46f9f709",
+                "id": "34bd357bcea3455ab1a159108b938a40",
                 "name": "Toolbox",
                 "cssStyle": {
                     "backgroundColor": "rgba(0, 151, 167, 0)",
@@ -161,15 +161,15 @@
                 "pinning": ""
             },
             "subparts": [
-                "8adf30b92f4c457b91c051fb7b7795c6"
+                "d48a916b60d64172830b6cc5f42471a4"
             ],
-            "ownerId": "9cabb0b4c7634714b2d46df391ac4c59"
+            "ownerId": "90cecb014285422d835eac5b35c62a0c"
         },
-        "8adf30b92f4c457b91c051fb7b7795c6": {
+        "d48a916b60d64172830b6cc5f42471a4": {
             "type": "area",
-            "id": "8adf30b92f4c457b91c051fb7b7795c6",
+            "id": "d48a916b60d64172830b6cc5f42471a4",
             "properties": {
-                "id": "8adf30b92f4c457b91c051fb7b7795c6",
+                "id": "d48a916b60d64172830b6cc5f42471a4",
                 "name": "",
                 "cssStyle": {
                     "width": "187px",
@@ -217,25 +217,26 @@
                 "list-alignment": "center"
             },
             "subparts": [
-                "b25e6f461bc0495e9d7a55f79ff28d5f",
-                "62919d7450ba4aa1b3662e58f6dce3ef",
-                "ac93f6a4c0434f6a860af8744ae5aa2f",
-                "d87fe98081a94724aa4118bc5bb40e1b",
-                "9b862e0843d843cbbf2bdbcc3166d39e",
-                "4787b001cbf94991b52f20932585e80a",
-                "240c99902b9d4211a7ba7116fe93e89d",
-                "4188cbbd66ef4927a8ca1f3e7aadd21a",
-                "adfd244384b54a8eaba18ae718d50d2e",
-                "1c1633669db946f38002a7a33736a340",
-                "409373e5c2b1443a939641e6e272a8a8"
+                "1c5e0842c9f843a1a25a4ca6f65b03fe",
+                "d18531d7da0c47e8ae56772818a420f9",
+                "ebca9d0cd8124b03b7d371c195471cfa",
+                "cae7564eec184ac0964da35066206e9a",
+                "c3188a09f66d41938116c841c0a3f352",
+                "6fd937f31f03433a85d52ea2c8084ce5",
+                "b5424aeb16ee43bcbb45a3a20b8e059a",
+                "5bc0aa68deaf41dc8bc17d6dba88f722",
+                "b86f327636b94491a600885309066276",
+                "eae9f705c9e44483981cfd7002413b07",
+                "1dc066008c3d4bb1bfa302a0835f6ae9",
+                "7dbc0fa8917541a08875aada3fc95fab"
             ],
-            "ownerId": "909dbda791d5486eb3f90c2f46f9f709"
+            "ownerId": "34bd357bcea3455ab1a159108b938a40"
         },
-        "b25e6f461bc0495e9d7a55f79ff28d5f": {
+        "1c5e0842c9f843a1a25a4ca6f65b03fe": {
             "type": "button",
-            "id": "b25e6f461bc0495e9d7a55f79ff28d5f",
+            "id": "1c5e0842c9f843a1a25a4ca6f65b03fe",
             "properties": {
-                "id": "b25e6f461bc0495e9d7a55f79ff28d5f",
+                "id": "1c5e0842c9f843a1a25a4ca6f65b03fe",
                 "name": "Add Button",
                 "script": "on click\n\tadd button to current card\nend click\n",
                 "cssStyle": {
@@ -282,13 +283,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         },
-        "62919d7450ba4aa1b3662e58f6dce3ef": {
+        "d18531d7da0c47e8ae56772818a420f9": {
             "type": "button",
-            "id": "62919d7450ba4aa1b3662e58f6dce3ef",
+            "id": "d18531d7da0c47e8ae56772818a420f9",
             "properties": {
-                "id": "62919d7450ba4aa1b3662e58f6dce3ef",
+                "id": "d18531d7da0c47e8ae56772818a420f9",
                 "name": "Add Image",
                 "script": "on click\n\tadd image to current card\nend click",
                 "cssStyle": {
@@ -337,13 +338,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         },
-        "ac93f6a4c0434f6a860af8744ae5aa2f": {
+        "ebca9d0cd8124b03b7d371c195471cfa": {
             "type": "button",
-            "id": "ac93f6a4c0434f6a860af8744ae5aa2f",
+            "id": "ebca9d0cd8124b03b7d371c195471cfa",
             "properties": {
-                "id": "ac93f6a4c0434f6a860af8744ae5aa2f",
+                "id": "ebca9d0cd8124b03b7d371c195471cfa",
                 "name": "Add Drawing",
                 "script": "on click\n\tadd drawing to current card\nend click",
                 "cssStyle": {
@@ -392,13 +393,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         },
-        "d87fe98081a94724aa4118bc5bb40e1b": {
+        "cae7564eec184ac0964da35066206e9a": {
             "type": "button",
-            "id": "d87fe98081a94724aa4118bc5bb40e1b",
+            "id": "cae7564eec184ac0964da35066206e9a",
             "properties": {
-                "id": "d87fe98081a94724aa4118bc5bb40e1b",
+                "id": "cae7564eec184ac0964da35066206e9a",
                 "name": "Add Area",
                 "script": "on click\n\tadd area to current card\nend click",
                 "cssStyle": {
@@ -447,13 +448,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         },
-        "9b862e0843d843cbbf2bdbcc3166d39e": {
+        "c3188a09f66d41938116c841c0a3f352": {
             "type": "button",
-            "id": "9b862e0843d843cbbf2bdbcc3166d39e",
+            "id": "c3188a09f66d41938116c841c0a3f352",
             "properties": {
-                "id": "9b862e0843d843cbbf2bdbcc3166d39e",
+                "id": "c3188a09f66d41938116c841c0a3f352",
                 "name": "Add Field",
                 "script": "on click\n\tadd field to current card\nend click",
                 "cssStyle": {
@@ -502,13 +503,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         },
-        "4787b001cbf94991b52f20932585e80a": {
+        "6fd937f31f03433a85d52ea2c8084ce5": {
             "type": "button",
-            "id": "4787b001cbf94991b52f20932585e80a",
+            "id": "6fd937f31f03433a85d52ea2c8084ce5",
             "properties": {
-                "id": "4787b001cbf94991b52f20932585e80a",
+                "id": "6fd937f31f03433a85d52ea2c8084ce5",
                 "name": "Add Card",
                 "script": "on click\n\tadd card\nend click",
                 "cssStyle": {
@@ -557,13 +558,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         },
-        "240c99902b9d4211a7ba7116fe93e89d": {
+        "b5424aeb16ee43bcbb45a3a20b8e059a": {
             "type": "button",
-            "id": "240c99902b9d4211a7ba7116fe93e89d",
+            "id": "b5424aeb16ee43bcbb45a3a20b8e059a",
             "properties": {
-                "id": "240c99902b9d4211a7ba7116fe93e89d",
+                "id": "b5424aeb16ee43bcbb45a3a20b8e059a",
                 "name": "Add Toolbox Button",
                 "script": "on click\n\tadd button\n\ttell last button to set \"width\" to \"fill\"\nend click",
                 "cssStyle": {
@@ -611,13 +612,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         },
-        "4188cbbd66ef4927a8ca1f3e7aadd21a": {
+        "5bc0aa68deaf41dc8bc17d6dba88f722": {
             "type": "button",
-            "id": "4188cbbd66ef4927a8ca1f3e7aadd21a",
+            "id": "5bc0aa68deaf41dc8bc17d6dba88f722",
             "properties": {
-                "id": "4188cbbd66ef4927a8ca1f3e7aadd21a",
+                "id": "5bc0aa68deaf41dc8bc17d6dba88f722",
                 "name": "Import World",
                 "script": "on click\n\timportWorld\nend click",
                 "cssStyle": {
@@ -666,13 +667,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         },
-        "adfd244384b54a8eaba18ae718d50d2e": {
+        "b86f327636b94491a600885309066276": {
             "type": "button",
-            "id": "adfd244384b54a8eaba18ae718d50d2e",
+            "id": "b86f327636b94491a600885309066276",
             "properties": {
-                "id": "adfd244384b54a8eaba18ae718d50d2e",
+                "id": "b86f327636b94491a600885309066276",
                 "name": "Import Local World",
                 "script": "on click \n\ttell this world to import\nend click ",
                 "cssStyle": {
@@ -722,13 +723,13 @@
                 "text-size": "15"
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         },
-        "1c1633669db946f38002a7a33736a340": {
+        "eae9f705c9e44483981cfd7002413b07": {
             "type": "button",
-            "id": "1c1633669db946f38002a7a33736a340",
+            "id": "eae9f705c9e44483981cfd7002413b07",
             "properties": {
-                "id": "1c1633669db946f38002a7a33736a340",
+                "id": "eae9f705c9e44483981cfd7002413b07",
                 "name": "Save",
                 "script": "on click \n\tif the \"name\" of this world == \"\"\n\tthen\n\t\task \"Please name me first\"\n\t\tput it into name\n\t\ttell this world to set \"name\" to name\n\t\ttell this world to save name\n\telse\n\t\ttell this world to save\n\tend if\n\nend click \n",
                 "cssStyle": {
@@ -776,13 +777,13 @@
                 "pinning": ""
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         },
-        "409373e5c2b1443a939641e6e272a8a8": {
+        "1dc066008c3d4bb1bfa302a0835f6ae9": {
             "type": "button",
-            "id": "409373e5c2b1443a939641e6e272a8a8",
+            "id": "1dc066008c3d4bb1bfa302a0835f6ae9",
             "properties": {
-                "id": "409373e5c2b1443a939641e6e272a8a8",
+                "id": "1dc066008c3d4bb1bfa302a0835f6ae9",
                 "name": "Save As",
                 "script": "on click \n\task \"What is my Name\"\n\ttell this world to save it\nend click ",
                 "cssStyle": {
@@ -832,7 +833,63 @@
                 "text-size": "15"
             },
             "subparts": [],
-            "ownerId": "8adf30b92f4c457b91c051fb7b7795c6"
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
+        },
+        "7dbc0fa8917541a08875aada3fc95fab": {
+            "type": "button",
+            "id": "7dbc0fa8917541a08875aada3fc95fab",
+            "properties": {
+                "id": "7dbc0fa8917541a08875aada3fc95fab",
+                "name": "Lock World",
+                "script": "on click \n\tif the \"lock\" of this world\n\tthen\n\t\ttell this world to set \"lock\" to false\n\t\tset \"name\" to \"Lock World\"\n\telse \n\t\ttell this world to set \"lock\" to true\n\t\tset \"name\" to \"Unlock World\"\n\tend if\nend click ",
+                "cssStyle": {
+                    "backgroundColor": "rgba(0, 151, 167, 1)",
+                    "opacity": 1,
+                    "border-top-style": "solid",
+                    "border-bottom-style": "solid",
+                    "border-left-style": "solid",
+                    "border-right-style": "solid",
+                    "border-top-width": "1px",
+                    "border-bottom-width": "1px",
+                    "border-left-width": "1px",
+                    "border-right-width": "1px",
+                    "border-top-color": "rgba(0, 0, 0, 1)",
+                    "border-bottom-color": "rgba(0, 0, 0, 1)",
+                    "border-left-color": "rgba(0, 0, 0, 1)",
+                    "border-right-color": "rgba(0, 0, 0, 1)",
+                    "border-left-transparency": 1,
+                    "box-shadow": "1px 1px 1px 0px rgba(238, 238, 238, 1)",
+                    "border-top-left-radius": "3px",
+                    "border-top-right-radius": "3px",
+                    "border-bottom-left-radius": "3px",
+                    "border-bottom-right-radius": "3px",
+                    "display": null,
+                    "top": "9px",
+                    "left": "10px",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid",
+                    "width": "100%"
+                },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(247, 241, 234, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": "15"
+                },
+                "number": 12,
+                "custom-properties": {},
+                "stepping": false,
+                "width": "fill",
+                "top": 9,
+                "left": 10,
+                "pinning": "",
+                "text-size": "15"
+            },
+            "subparts": [],
+            "ownerId": "d48a916b60d64172830b6cc5f42471a4"
         }
     }
 }</script>
@@ -842,7 +899,7 @@
 
 
 
-<st-editor class="open"><editor-props-list tab-name="properties" class=""><editor-prop-item name="background-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="background-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-bottom-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-bottom-style" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-bottom-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-bottom-width" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-left-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-left-style" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-left-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-left-width" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-right-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-right-style" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-right-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-right-width" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-top-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-top-style" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-top-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="border-top-width" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="bottom-padding" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="cantDelete" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="contents" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="corner-bottom-left-round" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="corner-bottom-right-round" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="corner-top-left-round" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="corner-top-right-round" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="dontSearch" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="editor-open" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="enabled" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="grid-size-columns" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="grid-size-rows" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="layout" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="left-padding" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="list-alignment" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="list-direction" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="list-distribution" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="list-wrapping" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="marked" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="number" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="rectangle" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="right-padding" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-blur" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-color" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-left" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-spread" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-top" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="shadow-transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="showPict" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="stepping" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="stepTime" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="top-padding" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="transparency" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item><editor-prop-item name="wants-move" owner-id="a5b46914830a40a680cad6acc1340f86"></editor-prop-item></editor-props-list><editor-messenger tab-name="messenger" class="show-pane"></editor-messenger><editor-custom-list tab-name="custom"></editor-custom-list><editor-subparts tab-name="subparts"><editor-location-info slot="ancestor-info" kind="stack" ref-id="9cabb0b4c7634714b2d46df391ac4c59"></editor-location-info><editor-location-info slot="ancestor-info" kind="card" class="hidden"></editor-location-info><editor-location-info slot="ancestor-info" kind="owner" ref-id="9cabb0b4c7634714b2d46df391ac4c59"></editor-location-info><button slot="button" data-type="window" title="Add a window to this card" class="add-part-button">
+<st-editor class="open"><editor-props-list tab-name="properties" class=""><editor-prop-item name="background-color" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="background-transparency" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-bottom-color" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-bottom-style" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-bottom-transparency" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-bottom-width" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-left-color" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-left-style" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-left-transparency" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-left-width" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-right-color" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-right-style" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-right-transparency" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-right-width" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-top-color" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-top-style" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-top-transparency" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="border-top-width" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="bottom-padding" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="cantDelete" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="contents" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="corner-bottom-left-round" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="corner-bottom-right-round" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="corner-top-left-round" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="corner-top-right-round" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="dontSearch" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="editor-open" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="enabled" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="grid-size-columns" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="grid-size-rows" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="layout" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="left-padding" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="list-alignment" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="list-direction" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="list-distribution" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="list-wrapping" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="marked" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="number" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="rectangle" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="right-padding" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="shadow-blur" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="shadow-color" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="shadow-left" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="shadow-spread" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="shadow-top" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="shadow-transparency" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="showPict" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="stepping" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="stepTime" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="top-padding" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="transparency" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="wants-context-menu" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item><editor-prop-item name="wants-move" owner-id="2477200f50f54a0780442baf89451f6f"></editor-prop-item></editor-props-list><editor-messenger tab-name="messenger" class="show-pane"></editor-messenger><editor-custom-list tab-name="custom"></editor-custom-list><editor-subparts tab-name="subparts"><editor-location-info slot="ancestor-info" kind="stack" ref-id="90cecb014285422d835eac5b35c62a0c"></editor-location-info><editor-location-info slot="ancestor-info" kind="card" class="hidden"></editor-location-info><editor-location-info slot="ancestor-info" kind="owner" ref-id="90cecb014285422d835eac5b35c62a0c"></editor-location-info><button slot="button" data-type="window" title="Add a window to this card" class="add-part-button">
 <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-window" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
   <path d="M12 3c-3.866 0 -7 3.272 -7 7v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1 -1v-10c0 -3.728 -3.134 -7 -7 -7z"></path>


### PR DESCRIPTION
### Main Points ###

This PR add a "lock" property to world. When this property is set to `true` no subparts of the world can open context, editor, or doIt command menus. There is nothing special about this property and it can be set or unset in the usual way. 

For example, if you have something that can send the world a command to change this property to false, nothing will prevent it from doing so, ie this is not some sort of lock on all changes. This is what the "lock/unliock" toggle button does in the toolbox for wysiwyg.html. 
However, if you did not a priori define such a function then you won't be able to do it later (since all scripting and in-context command execution is no longer available). You can do it from the browser devtools console, but that requires a bit of knowledge about the underlying system. 

In short, this is not a secure lock but it's a all around functional one. And, in addition, since locking is now controlled from a single property on a single part (the world) we can add whatever security is needed down the line. 

Additionally, I added a `wants-context-menu` prop to each part which is a nice way to control which parts and when get a context menu. 

Note: this PR is rebased on top of #154 


