### PR TITLE
removing watch

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
     entry: {
         devSystem: './js/objects/System.js',
     },
-    watch: true,
+    watch: false,
     output: {
         path: path.resolve(__dirname, 'js', 'objects', 'build'),
         filename: '[name].bundle.js'


### PR DESCRIPTION
removing the watch flag for webpack - not that useful for dev here since we dont want hot reload, and it interferes with other processes

can put in wit a special flag